### PR TITLE
feat: 글로벌 예외 처리 핸들러와 응답 공통 폼, 상태 코드 정의

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,9 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+	// Slack logback
+	implementation 'com.github.maricn:logback-slack-appender:1.6.1'
 }
 
 // queryDsl

--- a/src/main/java/com/flint/flint/common/BaseTimeEntity.java
+++ b/src/main/java/com/flint/flint/common/BaseTimeEntity.java
@@ -10,6 +10,11 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
+/**
+ * 생성, 수정일자에 대한 공통 필드 슈퍼 클래스
+ * @author 신승건
+ * @since 2023-08-04
+ */
 @MappedSuperclass
 @Getter
 @EntityListeners(AuditingEntityListener.class)

--- a/src/main/java/com/flint/flint/common/ResponseForm.java
+++ b/src/main/java/com/flint/flint/common/ResponseForm.java
@@ -1,0 +1,41 @@
+package com.flint.flint.common;
+
+import com.flint.flint.common.spec.ResultCode;
+
+/**
+ * 응답 바디 공통 DTO 양식
+ * 요청에 정상적으로 성공하면 data 사용, 에러가 발생하면 StatusResponse 핸들링
+ *
+ * @param <T> Response Body 의 dto 클래스 타입
+ * @author 신승건
+ * @since 2023-08-08
+ */
+public class ResponseForm<T> {
+
+    private StatusResponse statusResponse = new StatusResponse(ResultCode.OK); // 디폴트로 성공 처리
+    private final T data;
+
+    public ResponseForm() {
+        this.data = null;
+    }
+
+    /*
+        요청 성공 시, 응답 dto 객체를 파라미터로 받음
+     */
+    public ResponseForm(T data) {
+        this.data = data;
+    }
+
+    /*
+        요청 실패에 따른 생성자 처리
+     */
+    public ResponseForm(ResultCode resultCode) {
+        this();
+        this.statusResponse = new StatusResponse(resultCode);
+    }
+
+    public ResponseForm(String resultCode, String resultMessage) {
+        this();
+        this.statusResponse = new StatusResponse(resultCode, resultMessage);
+    }
+}

--- a/src/main/java/com/flint/flint/common/StatusResponse.java
+++ b/src/main/java/com/flint/flint/common/StatusResponse.java
@@ -1,0 +1,24 @@
+package com.flint.flint.common;
+
+import com.flint.flint.common.spec.ResultCode;
+import lombok.Getter;
+
+/**
+ * 요청 결과의 상태를 저장하는 클래스
+ * @author 신승건
+ * @since 2023-08-08
+ */
+@Getter
+public class StatusResponse {
+    private final String resultCode;
+    private final String resultMessage;
+
+    public StatusResponse(ResultCode resultCode) {
+        this(resultCode.getCode(), resultCode.getMessage());
+    }
+
+    public StatusResponse(String resultCode, String resultMessage) {
+        this.resultCode = resultCode;
+        this.resultMessage = resultMessage;
+    }
+}

--- a/src/main/java/com/flint/flint/common/exception/FlintCustomException.java
+++ b/src/main/java/com/flint/flint/common/exception/FlintCustomException.java
@@ -1,0 +1,31 @@
+package com.flint.flint.common.exception;
+
+import com.flint.flint.common.spec.ResultCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 클라이언트 에러(4xx)에 대한 플린트 서비스 최상위 커스텀 예외 클래스
+ *
+ * @author 신승건
+ * @since 2023-08-08
+ */
+@Getter
+public class FlintCustomException extends RuntimeException {
+
+    private final HttpStatus httpStatus; // HTTP 상태 코드
+    private final ResultCode resultCode; // 커스텀 결과 코드
+    private final String resultMessage; // 결과 메세지
+
+    public FlintCustomException(HttpStatus httpStatus, ResultCode resultCode) {
+        this(httpStatus, resultCode, resultCode.getMessage());
+    }
+
+    public FlintCustomException(HttpStatus httpStatus, ResultCode resultCode, String resultMessage) {
+        super(resultMessage);
+        this.httpStatus = httpStatus;
+        this.resultCode = resultCode;
+        this.resultMessage = resultMessage;
+    }
+
+}

--- a/src/main/java/com/flint/flint/common/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/flint/flint/common/handler/GlobalExceptionHandler.java
@@ -1,0 +1,53 @@
+package com.flint.flint.common.handler;
+
+import com.flint.flint.common.ResponseForm;
+import com.flint.flint.common.exception.FlintCustomException;
+import com.flint.flint.common.spec.ResultCode;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * 컨트롤러에서 발생하는 전역적인 예외를 캐치해서 핸들링
+ *
+ * @author 신승건
+ * @since 2023-08-08
+ */
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    /**
+     * 예기치 못한 서버 내부의 모든 에러를 핸들링 (상태코드 500 응답) + 에러 로그 내역을 슬랙으로 전송
+     *
+     * @param e       Java 최상위 예외 클래스
+     * @param request 요청 서블릿 객체
+     * @return internal server error 에 대한 에러 응답 json
+     */
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ResponseForm<Void>> handleInternalErrorException(Exception e, HttpServletRequest request) {
+        log.error("[서버 에러] from {} api", request.getRequestURI(), e);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
+                new ResponseForm<>(ResultCode.INTERNAL_SERVER_ERROR)
+        );
+    }
+
+    /**
+     * 클라이언트 에러를 커스터마이징하여 핸들링 (상태 코드 4xx 응답)
+     *
+     * @param e       커스텀 서비스 최상단 예외 클래스
+     * @param request 요청 서블릿 객체
+     * @return 커스텀 에러 코드의 내용에 따른 에러 응답 json
+     */
+    @ExceptionHandler(FlintCustomException.class)
+    protected ResponseEntity<ResponseForm<Void>> handleCustomClientErrorException(FlintCustomException e, HttpServletRequest request) {
+        log.warn("[클라이언트 에러] from {} api", request.getRequestURI(), e);
+        return ResponseEntity.status(e.getHttpStatus()).body(
+                new ResponseForm<>(e.getResultCode())
+        );
+    }
+
+}

--- a/src/main/java/com/flint/flint/common/spec/ResultCode.java
+++ b/src/main/java/com/flint/flint/common/spec/ResultCode.java
@@ -1,0 +1,36 @@
+package com.flint.flint.common.spec;
+
+import lombok.Getter;
+
+/**
+ * 커스텀 상태 코드 값 정의
+ * 각 도메인 별 비즈니스 로직 안에서 발생한 예외에 대한 상태 코드를 정의하기
+ *
+ * @author 신승건
+ * @since 2023-08-08
+ */
+@Getter
+public enum ResultCode {
+
+    // 정상 처리
+    OK("F000", "요청 정상 처리"),
+
+    // 서버 내부 에러 (5xx 에러)
+    INTERNAL_SERVER_ERROR("F100", "서버 에러 발생");
+
+    // F2xx: 인증, 권한에 대한 예외
+
+    // F3xx: 유저 예외
+
+    // F4xx: 커뮤니티, 게시글 예외
+
+    // F5xx: 모임 예외
+
+    private final String code;
+    private final String message;
+
+    ResultCode(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/flint/flint/community/domain/BoardCategory.java
+++ b/src/main/java/com/flint/flint/community/domain/BoardCategory.java
@@ -1,7 +1,7 @@
 package com.flint.flint.community.domain;
 
 import com.flint.flint.common.BaseTimeEntity;
-import com.flint.flint.community.specification.BoardCategoryType;
+import com.flint.flint.community.spec.BoardCategoryType;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/flint/flint/community/domain/Post.java
+++ b/src/main/java/com/flint/flint/community/domain/Post.java
@@ -6,6 +6,11 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+/**
+ * 게시글 엔티티
+ * @author 신승건
+ * @since 2023-08-04
+ */
 @Entity
 @Getter
 @NoArgsConstructor

--- a/src/main/java/com/flint/flint/community/domain/PostComment.java
+++ b/src/main/java/com/flint/flint/community/domain/PostComment.java
@@ -9,6 +9,11 @@ import lombok.NoArgsConstructor;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * 게시글 댓글 엔티티
+ * @author 신승건
+ * @since 2023-08-04
+ */
 @Entity
 @Getter
 @NoArgsConstructor

--- a/src/main/java/com/flint/flint/community/domain/PostCommentLike.java
+++ b/src/main/java/com/flint/flint/community/domain/PostCommentLike.java
@@ -6,6 +6,11 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+/**
+ * 게시글 댓글 좋아요 엔티티
+ * @author 신승건
+ * @since 2023-08-04
+ */
 @Entity
 @Getter
 @NoArgsConstructor

--- a/src/main/java/com/flint/flint/community/domain/PostImage.java
+++ b/src/main/java/com/flint/flint/community/domain/PostImage.java
@@ -6,6 +6,11 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+/**
+ * 게시글 이미지 엔티티
+ * @author 신승건
+ * @since 2023-08-04
+ */
 @Entity
 @Getter
 @NoArgsConstructor

--- a/src/main/java/com/flint/flint/community/domain/PostLike.java
+++ b/src/main/java/com/flint/flint/community/domain/PostLike.java
@@ -6,6 +6,11 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+/**
+ * 게시글 좋아요 엔티티
+ * @author 신승건
+ * @since 2023-08-04
+ */
 @Entity
 @Getter
 @NoArgsConstructor

--- a/src/main/java/com/flint/flint/community/domain/PostScrap.java
+++ b/src/main/java/com/flint/flint/community/domain/PostScrap.java
@@ -6,6 +6,11 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+/**
+ * 게시글 스크랩 엔티티
+ * @author 신승건
+ * @since 2023-08-04
+ */
 @Entity
 @Getter
 @NoArgsConstructor

--- a/src/main/java/com/flint/flint/community/spec/BoardCategoryType.java
+++ b/src/main/java/com/flint/flint/community/spec/BoardCategoryType.java
@@ -1,0 +1,11 @@
+package com.flint.flint.community.spec;
+
+/**
+ * 게시판 카테고리 타입 Enum (일반, 전공)
+ * @author 신승건
+ * @since 2023-08-04
+ */
+public enum BoardCategoryType {
+    NORMAL,
+    MAJOR
+}

--- a/src/main/java/com/flint/flint/community/specification/BoardCategoryType.java
+++ b/src/main/java/com/flint/flint/community/specification/BoardCategoryType.java
@@ -1,6 +1,0 @@
-package com.flint.flint.community.specification;
-
-public enum BoardCategoryType {
-    NORMAL,
-    MAJOR
-}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration>
+    <springProperty name="SLACK_WEBHOOK_URI" source="logging.slack.webhook-uri"/>
+    <appender name="SLACK" class="com.github.maricn.logback.SlackAppender">
+        <webhookUri>${SLACK_WEBHOOK_URI}</webhookUri>
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %msg %n</pattern>
+        </layout>
+        <username>Flint-API-Server-Internal-Error-log</username>
+        <colorCoding>true</colorCoding>
+    </appender>
+
+    <!-- Console appender 설정 -->
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <Pattern>%d %-5level %logger{35} - %msg%n</Pattern>
+        </encoder>
+    </appender>
+
+    <appender name="ASYNC_SLACK" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="SLACK"/>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="Console" />
+        <appender-ref ref="ASYNC_SLACK"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## 관련 이슈
close #16 
## 변경사항
- BoardCategoryType Enum을 specification → spec 패키지로 변경하였습니다.
- Slack에 에러 메세지 연동을 위해 의존성 추가와 logback xml 파일을 추가했습니다.
- 이전 작업에서 하지 못한 클래스 주석을 모두 달아주었습니다.
- 글로벌 예외 처리를 위해 예외처리 핸들러를 추가했습니다.
  - 4xx 클라이언트 에러의 경우, FlintCustomException 예외 클래스로 받아서, 에러 응답을 전달하도록 했고
  - 5xx 서버 에러의 경우, Java 최상위 예외 클래스인 Exception으로 받아서 에러 응답 전달과 에러 로깅을 통해 슬랙으로 메세지를 전달하도록 했습니다.
    - 실제 클라이언트에게 전달되는 서버 응답 메세지는 구체적으로 노출시키지 않고, 개발자만 알 수 있도록 슬랙과 연동했습니다. 
  - FlintCustomException의 경우 실제 HTTP 상태코드와 서비스에서 정의한 커스텀 결과 코드, 결과 메세지를 포함합니다. 
    - HTTP 상태코드는 해당 에러에 맞게 4xx 코드를 넣어주시면 됩니다.
- 상태 코드를 Enum으로 정의했습니다. 
  - 에러 뿐만 아니라, 모든 요청에 대한 응답의 상태 코드를 정의하도록 할 것입니다. 
  - 예외 클래스를 만드는 것이 아니라, 상태 코드를 만들고, 커스텀 예외 클래스로 해당 상태코드 값을 할당해주도록 설계했습니다. 
  - 상태코드는 기존 회의 때 정의한 것을 사용하지 않고, 제가 패턴을 수정하였습니다. 
- ResponseForm 이라는 클래스를 정의함으로써, 모든 요청에 대한 응답 바디 공통 폼을 정의했습니다. 
  - 요청에 성공해도, 실패해도 결과로써 응답 바디를 해당 클래스를 틀로 사용하면 됩니다.
  - data 필드는 제네릭으로 타입으로 받는데, 타입은 응답 바디로 전달할 dto 객체의 타입입니다. (응답 성공의 경우)
  - 응답 실패의 경우, data 필드는 null이 되며, statusResponse 필드를 통해 에러 메세지를 전달하는 방식으로 사용합니다. (성공의 경우 statusResponse는 건들지 않고, 디폴트로 성공의 상태 코드를 전달합니다. )
    - 오직 실패한 경우에만 statusResponse 값을 조작합니다.

## 개발하면서 발생한 문제점과 해결방안 또는 새롭게 알게된 점
x
## 당부하고 싶은 말 또는 논의해봐야할 점
- 슬랙 에러 메세지 연동을 위해 노션에 웹후크 URI 값을 공유하였습니다. 해당 값을 환경변수에 두시고 사용하시면 됩니다. 
- 위에 제가 말씀드린 예외 처리 설명이 이해가 되지 않으면 '예외 처리 가이드' 문서를 제가 자세하게 작성할 예정이니 참고바랍니다. 
## 스크린샷
x
## 기타 및 추후 계획
x
