### PR TITLE
feat: 학교 관련 asset 데이터를 정의하고 추가한다. 

### DIFF
--- a/src/main/java/com/flint/flint/asset/domain/UniversityAsset.java
+++ b/src/main/java/com/flint/flint/asset/domain/UniversityAsset.java
@@ -1,0 +1,52 @@
+package com.flint.flint.asset.domain;
+
+import com.flint.flint.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 대학교 정보 관련 데이터 보관용 엔티티
+ *
+ * @author 신승건
+ * @since 2023-08-30
+ */
+@Entity
+@Getter
+@NoArgsConstructor
+public class UniversityAsset extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "UNIVERSITY_ASSET_ID")
+    private Long id;
+
+    @Column(nullable = false)
+    private String universityName;
+
+    @Column(nullable = false)
+    private String logoUrl;
+
+    @Column(nullable = false)
+    private Integer red;
+
+    @Column(nullable = false)
+    private Integer green;
+
+    @Column(nullable = false)
+    private Integer blue;
+
+    @Column(nullable = false)
+    private String emailSuffix;
+
+    @Builder
+    public UniversityAsset(String universityName, String logoUrl, Integer red, Integer green, Integer blue, String emailSuffix) {
+        this.universityName = universityName;
+        this.logoUrl = logoUrl;
+        this.red = red;
+        this.green = green;
+        this.blue = blue;
+        this.emailSuffix = emailSuffix;
+    }
+}

--- a/src/main/java/com/flint/flint/asset/domain/UniversityMajor.java
+++ b/src/main/java/com/flint/flint/asset/domain/UniversityMajor.java
@@ -1,0 +1,48 @@
+package com.flint.flint.asset.domain;
+
+import com.flint.flint.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 대학교 별 학과 정보 및 분류 정보 엔티티
+ *
+ * @author 신승건
+ * @since 2023-08-30
+ */
+@Entity
+@Getter
+@NoArgsConstructor
+public class UniversityMajor extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "UNIVERSITY_MAJOR_ID")
+    private Long id;
+
+    @Column(nullable = false)
+    private String universityName; // 대학교 명
+
+    @Column(nullable = false)
+    private String majorName; // 학부 또는 학과명
+
+    @Column(nullable = false)
+    private String largeClass; // 대분류
+
+    @Column(nullable = false)
+    private String mediumClass; // 중분류
+
+    @Column(nullable = false)
+    private String smallClass; // 소분류
+
+    @Builder
+    public UniversityMajor(String universityName, String majorName, String largeClass, String mediumClass, String smallClass) {
+        this.universityName = universityName;
+        this.majorName = majorName;
+        this.largeClass = largeClass;
+        this.mediumClass = mediumClass;
+        this.smallClass = smallClass;
+    }
+}

--- a/src/main/java/com/flint/flint/club/domain/comment/ClubComment.java
+++ b/src/main/java/com/flint/flint/club/domain/comment/ClubComment.java
@@ -1,6 +1,7 @@
 package com.flint.flint.club.domain.comment;
 
 import com.flint.flint.club.domain.main.Club;
+import com.flint.flint.common.BaseTimeEntity;
 import com.flint.flint.member.domain.main.Member;
 import jakarta.persistence.*;
 import lombok.Builder;
@@ -19,7 +20,7 @@ import java.util.UUID;
 @Entity
 @NoArgsConstructor
 @Getter
-public class ClubComment {
+public class ClubComment extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "club_comment_id")

--- a/src/main/java/com/flint/flint/club/domain/comment/ClubCommentLike.java
+++ b/src/main/java/com/flint/flint/club/domain/comment/ClubCommentLike.java
@@ -1,5 +1,6 @@
 package com.flint.flint.club.domain.comment;
 
+import com.flint.flint.common.BaseTimeEntity;
 import com.flint.flint.member.domain.main.Member;
 import jakarta.persistence.*;
 import lombok.Builder;
@@ -17,7 +18,7 @@ import java.util.UUID;
 @Entity
 @Getter
 @NoArgsConstructor
-public class ClubCommentLike {
+public class ClubCommentLike extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "club_comment_like_id")

--- a/src/main/java/com/flint/flint/club/domain/main/ClubCategory.java
+++ b/src/main/java/com/flint/flint/club/domain/main/ClubCategory.java
@@ -2,6 +2,7 @@ package com.flint.flint.club.domain.main;
 
 import com.flint.flint.club.domain.spec.ClubCategoryType;
 import com.flint.flint.club.domain.spec.ClubFrequency;
+import com.flint.flint.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,7 +17,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor
-public class ClubCategory {
+public class ClubCategory extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "club_category_id")

--- a/src/main/java/com/flint/flint/club/domain/main/ClubEnvironment.java
+++ b/src/main/java/com/flint/flint/club/domain/main/ClubEnvironment.java
@@ -1,5 +1,6 @@
 package com.flint.flint.club.domain.main;
 
+import com.flint.flint.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Data;
@@ -19,7 +20,7 @@ import java.util.UUID;
 @Entity
 @Getter
 @NoArgsConstructor
-public class ClubEnvironment {
+public class ClubEnvironment extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "club_environment_id")

--- a/src/main/java/com/flint/flint/club/domain/main/ClubImage.java
+++ b/src/main/java/com/flint/flint/club/domain/main/ClubImage.java
@@ -1,5 +1,6 @@
 package com.flint.flint.club.domain.main;
 
+import com.flint.flint.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Data;
@@ -17,7 +18,7 @@ import java.util.UUID;
 @Entity
 @Getter
 @NoArgsConstructor
-public class ClubImage {
+public class ClubImage extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "club_image_id")

--- a/src/main/java/com/flint/flint/club/domain/main/ClubLike.java
+++ b/src/main/java/com/flint/flint/club/domain/main/ClubLike.java
@@ -1,5 +1,6 @@
 package com.flint.flint.club.domain.main;
 
+import com.flint.flint.common.BaseTimeEntity;
 import com.flint.flint.member.domain.main.Member;
 import jakarta.persistence.*;
 import lombok.Builder;
@@ -15,7 +16,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor
-public class ClubLike {
+public class ClubLike extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "club_id")

--- a/src/main/java/com/flint/flint/club/domain/main/ClubRequirement.java
+++ b/src/main/java/com/flint/flint/club/domain/main/ClubRequirement.java
@@ -2,6 +2,7 @@ package com.flint.flint.club.domain.main;
 
 import com.flint.flint.club.domain.spec.ClubGenderRequirement;
 import com.flint.flint.club.domain.spec.ClubJoinRequirement;
+import com.flint.flint.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,7 +22,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor
-public class ClubRequirement {
+public class ClubRequirement extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "club_Requirement_id")

--- a/src/main/java/com/flint/flint/club/domain/main/MemberInClub.java
+++ b/src/main/java/com/flint/flint/club/domain/main/MemberInClub.java
@@ -1,6 +1,7 @@
 package com.flint.flint.club.domain.main;
 
 import com.flint.flint.club.domain.spec.MemberJoinStatus;
+import com.flint.flint.common.BaseTimeEntity;
 import com.flint.flint.member.domain.main.Member;
 import jakarta.persistence.*;
 import lombok.Builder;
@@ -10,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor
-public class MemberInClub {
+public class MemberInClub extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;

--- a/src/main/java/com/flint/flint/club/repository/main/ClubCustomRepositoryImpl.java
+++ b/src/main/java/com/flint/flint/club/repository/main/ClubCustomRepositoryImpl.java
@@ -80,7 +80,7 @@ public class ClubCustomRepositoryImpl implements ClubCustomRepository {
         switch (property) {
             case "최신순":
                 log.info("최신 순으로 정렬");
-                return new OrderSpecifier(direction, club.createdDate);
+                return new OrderSpecifier(direction, club.createdAt);
             case "인기순":
                 log.info("인기 순으로 정렬");
                 return new OrderSpecifier(direction, memberInClub.club.count());

--- a/src/main/java/com/flint/flint/common/BaseTimeEntity.java
+++ b/src/main/java/com/flint/flint/common/BaseTimeEntity.java
@@ -12,6 +12,7 @@ import java.time.LocalDateTime;
 
 /**
  * 생성, 수정일자에 대한 공통 필드 슈퍼 클래스
+ *
  * @author 신승건
  * @since 2023-08-04
  */
@@ -22,8 +23,8 @@ public abstract class BaseTimeEntity {
 
     @CreatedDate
     @Column(updatable = false)
-    private LocalDateTime createdDate;
+    private LocalDateTime createdAt;
 
     @LastModifiedDate
-    private LocalDateTime modifiedDate;
+    private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/flint/flint/common/spec/ResultCode.java
+++ b/src/main/java/com/flint/flint/common/spec/ResultCode.java
@@ -23,7 +23,7 @@ public enum ResultCode {
     // F3xx: 유저 예외
 
     // F4xx: 커뮤니티, 게시글 예외
-    MAJOR_BOARD_NOT_FOUND("F400", "존재하지 않는 전공 게시판입니다.");
+    MAJOR_BOARD_NOT_FOUND("F400", "존재하지 않는 전공 게시판입니다."),
 
     // F5xx: 모임 예외
     CLUB_NOT_FOUND_ERROR("F500", "모임을 찾을 수 없습니다."),

--- a/src/main/java/com/flint/flint/community/domain/post/Post.java
+++ b/src/main/java/com/flint/flint/community/domain/post/Post.java
@@ -2,7 +2,7 @@ package com.flint.flint.community.domain.post;
 
 import com.flint.flint.common.BaseTimeEntity;
 import com.flint.flint.community.domain.board.Board;
-import com.flint.flint.member.domain.Member;
+import com.flint.flint.member.domain.main.Member;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 
 /**
  * 게시글 엔티티
+ *
  * @author 신승건
  * @since 2023-08-04
  */

--- a/src/main/java/com/flint/flint/community/domain/post/PostComment.java
+++ b/src/main/java/com/flint/flint/community/domain/post/PostComment.java
@@ -1,7 +1,7 @@
 package com.flint.flint.community.domain.post;
 
 import com.flint.flint.common.BaseTimeEntity;
-import com.flint.flint.member.domain.Member;
+import com.flint.flint.member.domain.main.Member;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/flint/flint/community/domain/post/PostCommentLike.java
+++ b/src/main/java/com/flint/flint/community/domain/post/PostCommentLike.java
@@ -1,7 +1,7 @@
 package com.flint.flint.community.domain.post;
 
 import com.flint.flint.common.BaseTimeEntity;
-import com.flint.flint.member.domain.Member;
+import com.flint.flint.member.domain.main.Member;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 
 /**
  * 게시글 댓글 좋아요 엔티티
+ *
  * @author 신승건
  * @since 2023-08-04
  */

--- a/src/main/java/com/flint/flint/community/domain/post/PostImage.java
+++ b/src/main/java/com/flint/flint/community/domain/post/PostImage.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 
 /**
  * 게시글 이미지 엔티티
+ *
  * @author 신승건
  * @since 2023-08-04
  */

--- a/src/main/java/com/flint/flint/community/domain/post/PostLike.java
+++ b/src/main/java/com/flint/flint/community/domain/post/PostLike.java
@@ -1,11 +1,7 @@
 package com.flint.flint.community.domain.post;
 
 import com.flint.flint.common.BaseTimeEntity;
-<<<<<<< HEAD:src/main/java/com/flint/flint/community/domain/post/PostLike.java
-import com.flint.flint.member.domain.Member;
-=======
-import com.flint.flint.community.domain.Post;
->>>>>>> develop:src/main/java/com/flint/flint/community/domain/PostLike.java
+import com.flint.flint.member.domain.main.Member;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,6 +9,7 @@ import lombok.NoArgsConstructor;
 
 /**
  * 게시글 좋아요 엔티티
+ *
  * @author 신승건
  * @since 2023-08-04
  */

--- a/src/main/java/com/flint/flint/community/domain/post/PostScrap.java
+++ b/src/main/java/com/flint/flint/community/domain/post/PostScrap.java
@@ -1,7 +1,7 @@
 package com.flint.flint.community.domain.post;
 
 import com.flint.flint.common.BaseTimeEntity;
-import com.flint.flint.member.domain.Member;
+import com.flint.flint.member.domain.main.Member;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 
 /**
  * 게시글 스크랩 엔티티
+ *
  * @author 신승건
  * @since 2023-08-04
  */

--- a/src/main/java/com/flint/flint/member/domain/main/Member.java
+++ b/src/main/java/com/flint/flint/member/domain/main/Member.java
@@ -12,10 +12,12 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
+
 import java.time.LocalDate;
 
 /**
  * 첫 생성시 별점 0점으로 초기화
+ *
  * @Author 정순원
  * @Since 2023-08-07
  */
@@ -44,11 +46,6 @@ public class Member extends BaseTimeEntity {
 
     @Max(5)
     @Min(0)
-<<<<<<< HEAD:src/main/java/com/flint/flint/member/domain/Member.java
-//    @Column(name = "evaluation", columnDefinition = "FLOAT(10,2) CONSTRAINT chk_evaluation CHECK (evaluation BETWEEN 0 AND 5)")
-=======
-    @Column(name = "evaluation")
->>>>>>> develop:src/main/java/com/flint/flint/member/domain/main/Member.java
     private Float evaluation = (float) 0;
 
     //유저, 관리자


### PR DESCRIPTION
## 관련 이슈
close #24 
## 변경사항
- Base Time Entity 생성 & 수정일자 필드명 변경
  - createDate → createdAt
  - modifiedDate → updatedAt
- 모임 도메인에서 BaseTimeEntity를 상속받지 않은 엔티티에 추가
- 패키징 변경에 따른 에러 수정
- 학교 관련 Asset 데이터 insert
  - 학교 별 학과 정보는 bulk insert로 데이터 추가
  - 일반 게시판, 전공 게시판 데이터는 직접 수작업 insert 쿼리로 데이터 추가 
  - 학교 별 로고 정보 및 이메일 정보는 하나의 테이블로 묶고, 해당 관련 파일은 준혁님이 주시는대로 bulk insert 예정이다. 
- 위 데이터를 애플리케이션 레벨에서 매핑하기 위해 UniversityAsset과 UniversityMajor 엔티티를 정의했다. 
- AWS S3에 로고 이미지 데이터 저장
## 개발하면서 발생한 문제점과 해결방안 또는 새롭게 알게된 점
- MySQL에서 csv 파일로 bulk insert를 처음 사용해보았다. 처음에는 엑셀로 import하려고 했지만 .csv 파일과 .json 파일만 지원이 되었다. 
  - 근데 csv 파일로 하니까 인코딩이 문제가 되어서 json으로 변환해서 사용해봤다. row가 거의 15000개 쯤 되니까 import하는데 시간이 꽤 걸렸다.
  - 테이블에 아무런 설정 없이 데이터가 들어가기 때문에 PK 설정과, 생성 & 수정 일자에 대한 설정을 별도의 쿼리문으로 추가해줬다. 
- 직접 insert 쿼리를 날리면 created_at과 updated_at 필드는 자동으로 안채워지나봅니다..
- JPA 상에서 엔티티 필드 명을 바꾸면 기존 필드명은 삭제되고 바꾼 필드명으로 추가가 되는 줄 알았더니 실제 데이터베이스를 확인해보니 기존 필드명, 바꾼 필드명 모두 존재했던 문제가 있었습니다. ddl-auto 값을 이것저것 바꿔도 동일하더군요..
## 당부하고 싶은 말 또는 논의해봐야할 점
### ! 절대로 개발용 데이터베이스 ddl-auto 값 바꿔서 asset 데이터 날라가지 않도록 주의 바랍니다 !
### 새로운 엔티티 설계할 때, BaseTimeEntity 잊지 마십쇼^^
### 엔티티 설계할 때, 필드명 등 제약조건 꼼꼼히 확인해주십쇼^^
## 스크린샷
x
## 기타 및 추후 계획
- 아직 추가하지 못한 학과 로고 & 이메일 정보에 대한 데이터 insert를 할 예정입니다. (코드 상으로는 관련이 없어 PR 먼저 올렸습니다.)
  - 2023-09-01 14:25에 추가했습니다
- 위 데이터를 바탕으로 데이터를 조회하는 기능을 구현할 예정입니다.
