### PR TITLE
Feat: 명함 뒷명 생성 혹은 수정 API

### DIFF
--- a/src/main/java/com/flint/flint/common/spec/ResultCode.java
+++ b/src/main/java/com/flint/flint/common/spec/ResultCode.java
@@ -43,16 +43,21 @@ public enum ResultCode {
     MEDIA_FILE_DELETE_ERROR("F606", "미디어 파일을 삭제하는데 문제가 발생했습니다."),
     UNEXPECTED_AWS_SERVICE_ERROR("F607", "AWS 서비스를 이용하는데 예상치 못한 문제가 발생했습니다."),
     NOT_EXIST_OBJECT_GIVEN_PATH("F608", "주어진 경로에 파일이 존재하지 않습니다"),
-  
+
     // F7xx: asset 예외
     NOT_FOUND_UNIVERSITY_NAME("F700", "존재하지 않는 대학 이름입니다."),
     EMPTY_MAJOR_SEARCH("F701", "검색 결과가 없습니다."),
 
+
     // F8xx: JSon 값 예외
-    NOT_VALIDATION("F800", "json 값이 올바르지 않습니다.");
-  
+    NOT_VALIDATION("F800", "json 값이 올바르지 않습니다."),
+
+    // F8xx: 명함 예외
+    IDCARD_NOT_FOUND("F900", "명함을 찾을 수 없습니다.");
+
     private final String code;
     private final String message;
+
 
     ResultCode(String code, String message) {
         this.code = code;

--- a/src/main/java/com/flint/flint/common/spec/ResultCode.java
+++ b/src/main/java/com/flint/flint/common/spec/ResultCode.java
@@ -52,7 +52,7 @@ public enum ResultCode {
     // F8xx: JSon 값 예외
     NOT_VALIDATION("F800", "json 값이 올바르지 않습니다."),
 
-    // F8xx: 명함 예외
+    // F9xx: 명함 예외
     IDCARD_NOT_FOUND("F900", "명함을 찾을 수 없습니다.");
 
     private final String code;

--- a/src/main/java/com/flint/flint/config/SecurityConfig.java
+++ b/src/main/java/com/flint/flint/config/SecurityConfig.java
@@ -31,9 +31,9 @@ public class SecurityConfig {
                 .httpBasic(httpBasic -> httpBasic.disable())
 
                 .authorizeRequests(authorizeRequests -> authorizeRequests
-                        .requestMatchers( new AntPathRequestMatcher("/api/v1/auth")
-                                , new AntPathRequestMatcher("/api/v1/mail")).permitAll())
-
+                        .requestMatchers("/api/v1/auth/**", "/api/v1/mail/**").permitAll()
+                        .requestMatchers("/api/v1/idcard/**").hasRole("AUTHUSER") //"ROLE_" 자동으로 붙여줘
+                )
                 .exceptionHandling(exceptionHandling -> exceptionHandling.authenticationEntryPoint(jwtAuthenticationEntryPoint)) ;
 
         http.addFilterBefore(new JwtAuthenticationFilter(jwtService), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/flint/flint/idcard/controller/IdCardUpdateController.java
+++ b/src/main/java/com/flint/flint/idcard/controller/IdCardUpdateController.java
@@ -5,10 +5,7 @@ import com.flint.flint.idcard.dto.request.IdCardRequest;
 import com.flint.flint.idcard.service.IdCardService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 /**
  * @author 정순원
@@ -21,9 +18,9 @@ public class IdCardUpdateController {
 
     private final IdCardService idCardService;
 
-    @PutMapping("/back/modify")
-    public ResponseForm updateIdCardBack(@Valid @RequestBody IdCardRequest.updateBackReqeust backReqeust) {
-        idCardService.updateBackIdCard(backReqeust);
+    @PutMapping("/back/{idCardId}")
+    public ResponseForm updateIdCardBack(@PathVariable Long idCardId, @Valid @RequestBody IdCardRequest.updateBackReqeust backReqeust) {
+        idCardService.updateBackIdCard(idCardId, backReqeust);
         return new ResponseForm<>();
     }
 }

--- a/src/main/java/com/flint/flint/idcard/controller/IdCardUpdateController.java
+++ b/src/main/java/com/flint/flint/idcard/controller/IdCardUpdateController.java
@@ -10,6 +10,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * @author 정순원
+ * @since 2023-09-10
+ */
 @RestController
 @RequestMapping("api/v1/idcard")
 @RequiredArgsConstructor

--- a/src/main/java/com/flint/flint/idcard/controller/IdCardUpdateController.java
+++ b/src/main/java/com/flint/flint/idcard/controller/IdCardUpdateController.java
@@ -1,0 +1,25 @@
+package com.flint.flint.idcard.controller;
+
+import com.flint.flint.common.ResponseForm;
+import com.flint.flint.idcard.dto.request.IdCardRequest;
+import com.flint.flint.idcard.service.IdCardService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/v1/idcard")
+@RequiredArgsConstructor
+public class IdCardUpdateController {
+
+    private final IdCardService idCardService;
+
+    @PostMapping("/update")
+    public ResponseForm updateIdCardBack(@Valid @RequestBody IdCardRequest.updateBackReqeust backReqeust) {
+        idCardService.saveOrUpdateBackIdCard(backReqeust);
+        return new ResponseForm<>();
+    }
+}

--- a/src/main/java/com/flint/flint/idcard/controller/IdCardUpdateController.java
+++ b/src/main/java/com/flint/flint/idcard/controller/IdCardUpdateController.java
@@ -5,7 +5,7 @@ import com.flint.flint.idcard.dto.request.IdCardRequest;
 import com.flint.flint.idcard.service.IdCardService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,9 +21,9 @@ public class IdCardUpdateController {
 
     private final IdCardService idCardService;
 
-    @PostMapping("/update")
+    @PutMapping("/back/modify")
     public ResponseForm updateIdCardBack(@Valid @RequestBody IdCardRequest.updateBackReqeust backReqeust) {
-        idCardService.saveOrUpdateBackIdCard(backReqeust);
+        idCardService.updateBackIdCard(backReqeust);
         return new ResponseForm<>();
     }
 }

--- a/src/main/java/com/flint/flint/idcard/domain/IdCard.java
+++ b/src/main/java/com/flint/flint/idcard/domain/IdCard.java
@@ -13,8 +13,8 @@ import lombok.NoArgsConstructor;
 import java.util.List;
 
 /**
- * @Author 정순원
- * @Since 2023-08-07
+ * @author 정순원
+ * @since 2023-08-07
  */
 @Entity
 @Getter
@@ -64,7 +64,7 @@ public class IdCard extends BaseTimeEntity {
         this.major = major;
     }
 
-    public void UpdateBack(String cardBackIntroduction, String cardBackMBTI, String cardBackSNSId, List<InterestType> cardBackInterestTypeList) {
+    public void updateBack(String cardBackIntroduction, String cardBackMBTI, String cardBackSNSId, List<InterestType> cardBackInterestTypeList) {
         this.cardBackIntroduction = cardBackIntroduction;
         this.cardBackMBTI = cardBackMBTI;
         this.cardBackSNSId = cardBackSNSId;

--- a/src/main/java/com/flint/flint/idcard/domain/IdCard.java
+++ b/src/main/java/com/flint/flint/idcard/domain/IdCard.java
@@ -1,11 +1,10 @@
-package com.flint.flint.member.domain.idcard;
+package com.flint.flint.idcard.domain;
 
 import com.flint.flint.common.BaseTimeEntity;
 import com.flint.flint.member.domain.main.Member;
-import com.flint.flint.member.spec.InterestType;
-import com.flint.flint.member.spec.InterestConverter;
+import com.flint.flint.idcard.spec.InterestType;
+import com.flint.flint.idcard.spec.InterestConverter;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/flint/flint/idcard/domain/IdCard.java
+++ b/src/main/java/com/flint/flint/idcard/domain/IdCard.java
@@ -63,4 +63,11 @@ public class IdCard extends BaseTimeEntity {
         this.university = university;
         this.major = major;
     }
+
+    public void UpdateBack(String cardBackIntroduction, String cardBackMBTI, String cardBackSNSId, List<InterestType> cardBackInterestTypeList) {
+        this.cardBackIntroduction = cardBackIntroduction;
+        this.cardBackMBTI = cardBackMBTI;
+        this.cardBackSNSId = cardBackSNSId;
+        this.cardBackInterestTypeList = cardBackInterestTypeList;
+    }
 }

--- a/src/main/java/com/flint/flint/idcard/domain/IdCardBox.java
+++ b/src/main/java/com/flint/flint/idcard/domain/IdCardBox.java
@@ -1,4 +1,4 @@
-package com.flint.flint.member.domain.idcard;
+package com.flint.flint.idcard.domain;
 
 import com.flint.flint.club.domain.main.Club;
 import com.flint.flint.common.BaseTimeEntity;

--- a/src/main/java/com/flint/flint/idcard/dto/request/IdCardRequest.java
+++ b/src/main/java/com/flint/flint/idcard/dto/request/IdCardRequest.java
@@ -1,0 +1,24 @@
+package com.flint.flint.idcard.dto.request;
+
+import com.flint.flint.idcard.spec.InterestType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class IdCardRequest {
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class  updateBackReqeust {
+        private Long idCardId;
+        private String cardBackIntroduction;
+        private String cardBackSNSId;
+        private String cardBackMBTI;
+        private List<InterestType> cardBackInterestTypeList;
+    }
+}

--- a/src/main/java/com/flint/flint/idcard/dto/request/IdCardRequest.java
+++ b/src/main/java/com/flint/flint/idcard/dto/request/IdCardRequest.java
@@ -20,7 +20,6 @@ public class IdCardRequest {
     @AllArgsConstructor
     @Builder
     public static class  updateBackReqeust {
-
         private String cardBackIntroduction;
         private String cardBackSNSId;
         private String cardBackMBTI;

--- a/src/main/java/com/flint/flint/idcard/dto/request/IdCardRequest.java
+++ b/src/main/java/com/flint/flint/idcard/dto/request/IdCardRequest.java
@@ -8,6 +8,10 @@ import lombok.NoArgsConstructor;
 
 import java.util.List;
 
+/**
+ * @author 정순원
+ * @since 2023-09-10
+ */
 public class IdCardRequest {
 
     @Data

--- a/src/main/java/com/flint/flint/idcard/dto/request/IdCardRequest.java
+++ b/src/main/java/com/flint/flint/idcard/dto/request/IdCardRequest.java
@@ -20,8 +20,7 @@ public class IdCardRequest {
     @AllArgsConstructor
     @Builder
     public static class  updateBackReqeust {
-        @NotBlank
-        private Long idCardId;
+
         private String cardBackIntroduction;
         private String cardBackSNSId;
         private String cardBackMBTI;

--- a/src/main/java/com/flint/flint/idcard/dto/request/IdCardRequest.java
+++ b/src/main/java/com/flint/flint/idcard/dto/request/IdCardRequest.java
@@ -1,6 +1,7 @@
 package com.flint.flint.idcard.dto.request;
 
 import com.flint.flint.idcard.spec.InterestType;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -19,6 +20,7 @@ public class IdCardRequest {
     @AllArgsConstructor
     @Builder
     public static class  updateBackReqeust {
+        @NotBlank
         private Long idCardId;
         private String cardBackIntroduction;
         private String cardBackSNSId;

--- a/src/main/java/com/flint/flint/idcard/dto/response/IdCardResponse.java
+++ b/src/main/java/com/flint/flint/idcard/dto/response/IdCardResponse.java
@@ -1,4 +1,8 @@
 package com.flint.flint.idcard.dto.response;
 
+/**
+ * @author 정순원
+ * @since 2023-09-10
+ */
 public class IdCardResponse {
 }

--- a/src/main/java/com/flint/flint/idcard/dto/response/IdCardResponse.java
+++ b/src/main/java/com/flint/flint/idcard/dto/response/IdCardResponse.java
@@ -1,0 +1,4 @@
+package com.flint.flint.idcard.dto.response;
+
+public class IdCardResponse {
+}

--- a/src/main/java/com/flint/flint/idcard/repository/IdCardJPARepository.java
+++ b/src/main/java/com/flint/flint/idcard/repository/IdCardJPARepository.java
@@ -3,5 +3,9 @@ package com.flint.flint.idcard.repository;
 import com.flint.flint.idcard.domain.IdCard;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+/**
+ * @author 정순원
+ * @since 2023-09-10
+ */
 public interface IdCardJPARepository extends JpaRepository<IdCard, Long>, IdcardRepositoryCustom {
 }

--- a/src/main/java/com/flint/flint/idcard/repository/IdCardJPARepository.java
+++ b/src/main/java/com/flint/flint/idcard/repository/IdCardJPARepository.java
@@ -3,5 +3,5 @@ package com.flint.flint.idcard.repository;
 import com.flint.flint.idcard.domain.IdCard;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface IdCardRepository extends JpaRepository<IdCard, Long> {
+public interface IdCardJPARepository extends JpaRepository<IdCard, Long>, IdcardRepositoryCustom {
 }

--- a/src/main/java/com/flint/flint/idcard/repository/IdCardRepository.java
+++ b/src/main/java/com/flint/flint/idcard/repository/IdCardRepository.java
@@ -1,6 +1,6 @@
-package com.flint.flint.member.repository;
+package com.flint.flint.idcard.repository;
 
-import com.flint.flint.member.domain.idcard.IdCard;
+import com.flint.flint.idcard.domain.IdCard;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface IdCardRepository extends JpaRepository<IdCard, Long> {

--- a/src/main/java/com/flint/flint/idcard/repository/IdCardRepositoryImpl.java
+++ b/src/main/java/com/flint/flint/idcard/repository/IdCardRepositoryImpl.java
@@ -1,0 +1,12 @@
+package com.flint.flint.idcard.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class IdCardRepositoryImpl implements IdcardRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+
+}

--- a/src/main/java/com/flint/flint/idcard/repository/IdCardRepositoryImpl.java
+++ b/src/main/java/com/flint/flint/idcard/repository/IdCardRepositoryImpl.java
@@ -3,6 +3,10 @@ package com.flint.flint.idcard.repository;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
+/**
+ * @author 정순원
+ * @since 2023-09-10
+ */
 @RequiredArgsConstructor
 public class IdCardRepositoryImpl implements IdcardRepositoryCustom {
 

--- a/src/main/java/com/flint/flint/idcard/repository/IdcardRepositoryCustom.java
+++ b/src/main/java/com/flint/flint/idcard/repository/IdcardRepositoryCustom.java
@@ -1,0 +1,4 @@
+package com.flint.flint.idcard.repository;
+
+public interface IdcardRepositoryCustom {
+}

--- a/src/main/java/com/flint/flint/idcard/repository/IdcardRepositoryCustom.java
+++ b/src/main/java/com/flint/flint/idcard/repository/IdcardRepositoryCustom.java
@@ -1,4 +1,8 @@
 package com.flint.flint.idcard.repository;
 
+/**
+ * @author 정순원
+ * @since 2023-09-10
+ */
 public interface IdcardRepositoryCustom {
 }

--- a/src/main/java/com/flint/flint/idcard/service/IdCardService.java
+++ b/src/main/java/com/flint/flint/idcard/service/IdCardService.java
@@ -15,6 +15,11 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+/**
+ * 명함 서비스
+ * @author 정순원
+ * @since 2023-09-10
+ */
 @Service
 @RequiredArgsConstructor
 public class IdCardService {
@@ -42,10 +47,9 @@ public class IdCardService {
 
         IdCard idCard = getIdCard(idCardId);
         idCard.UpdateBack(cardBackIntroduction, cardBackMBTI, cardBackSNSId, cardBackInterestTypeList);
-        idCardJPARepository.save(idCard);
     }
 
     private IdCard getIdCard(Long idCardId) {
-        return idCardJPARepository.findById(idCardId).orElseThrow(() -> new FlintCustomException(HttpStatus.BAD_REQUEST, ResultCode.IDCARD_NOT_FOUND));
+        return idCardJPARepository.findById(idCardId).orElseThrow(() -> new FlintCustomException(HttpStatus.NOT_FOUND, ResultCode.IDCARD_NOT_FOUND));
     }
 }

--- a/src/main/java/com/flint/flint/idcard/service/IdCardService.java
+++ b/src/main/java/com/flint/flint/idcard/service/IdCardService.java
@@ -38,14 +38,13 @@ public class IdCardService {
     }
 
     @Transactional
-    public void updateBackIdCard(IdCardRequest.updateBackReqeust request) {
-        Long idCardId = request.getIdCardId();
+    public void updateBackIdCard(Long IdCardId, IdCardRequest.updateBackReqeust request) {
         String cardBackMBTI = request.getCardBackMBTI();
         String cardBackSNSId = request.getCardBackSNSId();
         List<InterestType> cardBackInterestTypeList = request.getCardBackInterestTypeList();
         String cardBackIntroduction = request.getCardBackIntroduction();
 
-        IdCard idCard = getIdCard(idCardId);
+        IdCard idCard = getIdCard(IdCardId);
         idCard.updateBack(cardBackIntroduction, cardBackMBTI, cardBackSNSId, cardBackInterestTypeList);
     }
 

--- a/src/main/java/com/flint/flint/idcard/service/IdCardService.java
+++ b/src/main/java/com/flint/flint/idcard/service/IdCardService.java
@@ -1,18 +1,25 @@
 package com.flint.flint.idcard.service;
 
+import com.flint.flint.common.exception.FlintCustomException;
+import com.flint.flint.common.spec.ResultCode;
+import com.flint.flint.idcard.dto.request.IdCardRequest;
+import com.flint.flint.idcard.spec.InterestType;
 import com.flint.flint.mail.dto.request.SuccessUniversityAuthRequest;
 import com.flint.flint.idcard.domain.IdCard;
 import com.flint.flint.member.domain.main.Member;
-import com.flint.flint.idcard.repository.IdCardRepository;
+import com.flint.flint.idcard.repository.IdCardJPARepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class IdCardService {
 
-    private final IdCardRepository idCardRepository;
+    private final IdCardJPARepository idCardJPARepository;
 
     @Transactional
     public void saveFrontIdCard(Member member, SuccessUniversityAuthRequest request) {
@@ -22,8 +29,23 @@ public class IdCardService {
                 .university(request.getUniversity())
                 .major(request.getMajor())
                 .build();
-        idCardRepository.save(idcard);
+        idCardJPARepository.save(idcard);
     }
 
+    @Transactional
+    public void saveOrUpdateBackIdCard(IdCardRequest.updateBackReqeust reqeust) {
+        Long idCardId = reqeust.getIdCardId();
+        String cardBackMBTI = reqeust.getCardBackMBTI();
+        String cardBackSNSId = reqeust.getCardBackSNSId();
+        List<InterestType> cardBackInterestTypeList = reqeust.getCardBackInterestTypeList();
+        String cardBackIntroduction = reqeust.getCardBackIntroduction();
 
+        IdCard idCard = getIdCard(idCardId);
+        idCard.UpdateBack(cardBackIntroduction, cardBackMBTI, cardBackSNSId, cardBackInterestTypeList);
+        idCardJPARepository.save(idCard);
+    }
+
+    private IdCard getIdCard(Long idCardId) {
+        return idCardJPARepository.findById(idCardId).orElseThrow(() -> new FlintCustomException(HttpStatus.BAD_REQUEST, ResultCode.IDCARD_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/flint/flint/idcard/service/IdCardService.java
+++ b/src/main/java/com/flint/flint/idcard/service/IdCardService.java
@@ -1,9 +1,9 @@
-package com.flint.flint.member.service;
+package com.flint.flint.idcard.service;
 
 import com.flint.flint.mail.dto.request.SuccessUniversityAuthRequest;
-import com.flint.flint.member.domain.idcard.IdCard;
+import com.flint.flint.idcard.domain.IdCard;
 import com.flint.flint.member.domain.main.Member;
-import com.flint.flint.member.repository.IdCardRepository;
+import com.flint.flint.idcard.repository.IdCardRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/flint/flint/idcard/service/IdCardService.java
+++ b/src/main/java/com/flint/flint/idcard/service/IdCardService.java
@@ -38,15 +38,15 @@ public class IdCardService {
     }
 
     @Transactional
-    public void saveOrUpdateBackIdCard(IdCardRequest.updateBackReqeust reqeust) {
-        Long idCardId = reqeust.getIdCardId();
-        String cardBackMBTI = reqeust.getCardBackMBTI();
-        String cardBackSNSId = reqeust.getCardBackSNSId();
-        List<InterestType> cardBackInterestTypeList = reqeust.getCardBackInterestTypeList();
-        String cardBackIntroduction = reqeust.getCardBackIntroduction();
+    public void updateBackIdCard(IdCardRequest.updateBackReqeust request) {
+        Long idCardId = request.getIdCardId();
+        String cardBackMBTI = request.getCardBackMBTI();
+        String cardBackSNSId = request.getCardBackSNSId();
+        List<InterestType> cardBackInterestTypeList = request.getCardBackInterestTypeList();
+        String cardBackIntroduction = request.getCardBackIntroduction();
 
         IdCard idCard = getIdCard(idCardId);
-        idCard.UpdateBack(cardBackIntroduction, cardBackMBTI, cardBackSNSId, cardBackInterestTypeList);
+        idCard.updateBack(cardBackIntroduction, cardBackMBTI, cardBackSNSId, cardBackInterestTypeList);
     }
 
     private IdCard getIdCard(Long idCardId) {

--- a/src/main/java/com/flint/flint/idcard/spec/InterestConverter.java
+++ b/src/main/java/com/flint/flint/idcard/spec/InterestConverter.java
@@ -1,4 +1,4 @@
-package com.flint.flint.member.spec;
+package com.flint.flint.idcard.spec;
 
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;

--- a/src/main/java/com/flint/flint/idcard/spec/InterestConverter.java
+++ b/src/main/java/com/flint/flint/idcard/spec/InterestConverter.java
@@ -25,7 +25,7 @@ public class InterestConverter implements AttributeConverter<List<InterestType>,
     @Override
     public String convertToDatabaseColumn(List<InterestType> attribute) {
 
-        if (attribute.isEmpty() || attribute == null) {
+        if (attribute == null || attribute.isEmpty()) {
             return null;
         }
 

--- a/src/main/java/com/flint/flint/idcard/spec/InterestType.java
+++ b/src/main/java/com/flint/flint/idcard/spec/InterestType.java
@@ -1,4 +1,4 @@
-package com.flint.flint.member.spec;
+package com.flint.flint.idcard.spec;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/flint/flint/mail/service/MailService.java
+++ b/src/main/java/com/flint/flint/mail/service/MailService.java
@@ -6,7 +6,7 @@ import com.flint.flint.mail.dto.request.SuccessUniversityAuthRequest;
 import com.flint.flint.mail.dto.response.EmailAuthNumberRespose;
 import com.flint.flint.member.domain.main.Member;
 import com.flint.flint.member.spec.Authority;
-import com.flint.flint.member.service.IdCardService;
+import com.flint.flint.idcard.service.IdCardService;
 import com.flint.flint.member.service.MemberService;
 import com.flint.flint.redis.RedisUtil;
 import com.flint.flint.security.auth.AuthenticationService;

--- a/src/main/java/com/flint/flint/member/service/MemberService.java
+++ b/src/main/java/com/flint/flint/member/service/MemberService.java
@@ -11,6 +11,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import static com.flint.flint.common.spec.ResultCode.*;
 
+/**
+ * @author 정순원
+ * @since 2023-09-10
+ */
 @Service
 @RequiredArgsConstructor
 public class MemberService {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: create-drop
     properties:
       hibernate:
         format_sql: true

--- a/src/test/java/com/flint/flint/idcard/service/IdCardServiceTest.java
+++ b/src/test/java/com/flint/flint/idcard/service/IdCardServiceTest.java
@@ -56,19 +56,23 @@ class IdCardServiceTest {
     @Test
     @DisplayName("카드 뒷면 수정 테스트")
     void updateBackIdCard() {
+        //given
         List<InterestType> list = new ArrayList<>();
         list.add(InterestType.GAME);
         list.add(InterestType.MOVIE);
         IdCardRequest.updateBackReqeust updateBackReqeust = IdCardRequest.updateBackReqeust.builder()
-                .idCardId(1L)
                 .cardBackIntroduction("안녕하세요")
                 .cardBackSNSId("io.onl")
                 .cardBackMBTI("ENTJ")
                 .cardBackInterestTypeList(list)
                 .build();
+        Long idCardId = 1L;
 
-        idCardService.updateBackIdCard(updateBackReqeust);
-        IdCard idCard = idCardJPARepository.findById(updateBackReqeust.getIdCardId()).orElseThrow(() -> new FlintCustomException(HttpStatus.NOT_FOUND, IDCARD_NOT_FOUND));
+        //when
+        idCardService.updateBackIdCard(idCardId,updateBackReqeust);
+
+        //then
+        IdCard idCard = idCardJPARepository.findById(1L).orElseThrow(() -> new FlintCustomException(HttpStatus.NOT_FOUND, IDCARD_NOT_FOUND));
         assertEquals(1L, idCard.getId());
         assertEquals("안녕하세요", idCard.getCardBackIntroduction());
         assertEquals("io.onl", idCard.getCardBackSNSId());

--- a/src/test/java/com/flint/flint/idcard/service/IdCardServiceTest.java
+++ b/src/test/java/com/flint/flint/idcard/service/IdCardServiceTest.java
@@ -8,30 +8,21 @@ import com.flint.flint.idcard.spec.InterestType;
 import com.flint.flint.member.domain.main.Member;
 import com.flint.flint.member.repository.MemberRepository;
 import com.flint.flint.member.spec.Authority;
-import com.flint.flint.security.auth.dto.AuthorityMemberDTO;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 
 import static com.flint.flint.common.spec.ResultCode.IDCARD_NOT_FOUND;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)class IdCardServiceTest {
+@Transactional
+class IdCardServiceTest {
 
     @Autowired
     IdCardService idCardService;
@@ -40,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
     @Autowired
     IdCardJPARepository idCardJPARepository;
 
-    @BeforeAll
+    @BeforeEach
     void setUp() {
         Member member = Member.builder()
                 .providerName("kakao")
@@ -64,7 +55,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
     @Test
     @DisplayName("카드 뒷면 수정 테스트")
-    void saveOrUpdateBackIdCard() {
+    void updateBackIdCard() {
         List<InterestType> list = new ArrayList<>();
         list.add(InterestType.GAME);
         list.add(InterestType.MOVIE);
@@ -76,7 +67,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
                 .cardBackInterestTypeList(list)
                 .build();
 
-        idCardService.saveOrUpdateBackIdCard(updateBackReqeust);
+        idCardService.updateBackIdCard(updateBackReqeust);
         IdCard idCard = idCardJPARepository.findById(updateBackReqeust.getIdCardId()).orElseThrow(() -> new FlintCustomException(HttpStatus.NOT_FOUND, IDCARD_NOT_FOUND));
         assertEquals(1L, idCard.getId());
         assertEquals("안녕하세요", idCard.getCardBackIntroduction());

--- a/src/test/java/com/flint/flint/idcard/service/IdCardServiceTest.java
+++ b/src/test/java/com/flint/flint/idcard/service/IdCardServiceTest.java
@@ -1,0 +1,87 @@
+package com.flint.flint.idcard.service;
+
+import com.flint.flint.common.exception.FlintCustomException;
+import com.flint.flint.idcard.domain.IdCard;
+import com.flint.flint.idcard.dto.request.IdCardRequest;
+import com.flint.flint.idcard.repository.IdCardJPARepository;
+import com.flint.flint.idcard.spec.InterestType;
+import com.flint.flint.member.domain.main.Member;
+import com.flint.flint.member.repository.MemberRepository;
+import com.flint.flint.member.spec.Authority;
+import com.flint.flint.security.auth.dto.AuthorityMemberDTO;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+import static com.flint.flint.common.spec.ResultCode.IDCARD_NOT_FOUND;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)class IdCardServiceTest {
+
+    @Autowired
+    IdCardService idCardService;
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    IdCardJPARepository idCardJPARepository;
+
+    @BeforeAll
+    void setUp() {
+        Member member = Member.builder()
+                .providerName("kakao")
+                .email("test@test.com")
+                .providerId("test")
+                .authority(Authority.AUTHUSER)
+                .build();
+
+        memberRepository.save(member);
+
+        IdCard idCard = IdCard.builder()
+                .member(member)
+                .admissionYear(2020)
+                .major("test")
+                .university("test")
+                .build();
+
+        idCardJPARepository.save(idCard);
+
+    }
+
+    @Test
+    @DisplayName("카드 뒷면 수정 테스트")
+    void saveOrUpdateBackIdCard() {
+        List<InterestType> list = new ArrayList<>();
+        list.add(InterestType.GAME);
+        list.add(InterestType.MOVIE);
+        IdCardRequest.updateBackReqeust updateBackReqeust = IdCardRequest.updateBackReqeust.builder()
+                .idCardId(1L)
+                .cardBackIntroduction("안녕하세요")
+                .cardBackSNSId("io.onl")
+                .cardBackMBTI("ENTJ")
+                .cardBackInterestTypeList(list)
+                .build();
+
+        idCardService.saveOrUpdateBackIdCard(updateBackReqeust);
+        IdCard idCard = idCardJPARepository.findById(updateBackReqeust.getIdCardId()).orElseThrow(() -> new FlintCustomException(HttpStatus.NOT_FOUND, IDCARD_NOT_FOUND));
+        assertEquals(1L, idCard.getId());
+        assertEquals("안녕하세요", idCard.getCardBackIntroduction());
+        assertEquals("io.onl", idCard.getCardBackSNSId());
+        assertEquals("ENTJ", idCard.getCardBackMBTI());
+        assertEquals(list, idCard.getCardBackInterestTypeList());
+    }
+}


### PR DESCRIPTION
## 관련 이슈
close #45 
## 변경사항
 - 명함 생성 혹은 수정 API 
 - 명함 생성 혹은 수정 API 테스트 
 - 리퍼지토리 생성 
## 개발하면서 발생한 문제점과 해결방안 또는 새롭게 알게된 점

컨버터에서 에러가 났습니다. isempty()는 nullpoint인셉션을 던지기 때문에, 쓰기 전 null 검사를 해줘야 한다는 것을 알았습니다. 그래서 널 검사와 isempty() 검사 순서를 바꿨습니다. 

퍼사든 패턴을 공부하여 염두해두고 코드를 짰습니다.

책임 분리를 위해 객체를 바꾸는 로직은 엔티티 단에서 구현하였습니다 
## 당부하고 싶은 말 또는 논의해봐야할 점
프로그램은 돌아가지만 아직도 
모든 테이블에 
이러한 문구가 뜹니다
![image](https://github.com/Flint-org/Flint-API-Server/assets/92251131/4616897b-d18d-47fa-92e9-b0478befa227)

## 스크린샷
![image](https://github.com/Flint-org/Flint-API-Server/assets/92251131/42d05ebf-7dab-4303-83a6-d2df334fe0ef)

## 기타 및 추후 계획
  - [ ] 자신 명함 앞면 불러오기 API
