### PR TITLE
feat: Asset 데이터 조회 API 컨트롤러 구현

### DIFF
--- a/src/main/java/com/flint/flint/asset/controller/AssetApiController.java
+++ b/src/main/java/com/flint/flint/asset/controller/AssetApiController.java
@@ -1,0 +1,83 @@
+package com.flint.flint.asset.controller;
+
+import com.flint.flint.asset.dto.LogoInfoResponse;
+import com.flint.flint.asset.dto.MajorsResponse;
+import com.flint.flint.asset.dto.UniversityEmailResponse;
+import com.flint.flint.asset.service.AssetService;
+import com.flint.flint.common.ResponseForm;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * 학교 자료 컨트롤러
+ *
+ * @author 신승건
+ * @since 2023-09-11
+ */
+@RestController
+@RequestMapping("/api/v1/assets")
+@RequiredArgsConstructor
+public class AssetApiController {
+    private final AssetService assetService;
+
+
+    /**
+     * 학교 로고 정보 조회 API
+     *
+     * @param universityName 학교 이름
+     */
+    @GetMapping("/logo/{universityName}")
+    public ResponseForm<LogoInfoResponse> getLogoInformation(
+            @PathVariable("universityName") String universityName
+    ) {
+        return new ResponseForm<>(assetService.getUniversityLogoInfoByName(universityName));
+    }
+
+    /**
+     * 학교 이메일 정보 조회 API
+     *
+     * @param universityName 학교 이름
+     */
+    @GetMapping("/email/{universityName}")
+    public ResponseForm<UniversityEmailResponse> getEmailInformation(
+            @PathVariable("universityName") String universityName
+    ) {
+        return new ResponseForm<>(assetService.getUniversityEmailByName(universityName));
+    }
+
+    /**
+     * 전체 학교 목록 조회 API
+     */
+    @GetMapping("/universities")
+    public ResponseForm<List<String>> getUniversities() {
+        return new ResponseForm<>(assetService.getUniversities());
+    }
+
+    /**
+     * 학교의 전체 전공 대분류 목록 조회
+     *
+     * @param universityName 학교 이름
+     */
+    @GetMapping("/majors/large-class/{universityName}")
+    public ResponseForm<List<String>> getLargeClasses(
+            @PathVariable("universityName") String universityName
+    ) {
+        return new ResponseForm<>(assetService.getLargeClassesByName(universityName));
+    }
+
+    /**
+     * 특정 학교와 특정 대분류에 해당하는 전공 목록 조회
+     *
+     * @param universityName 학교 이름
+     * @param largeClass     대분류 이름
+     */
+    @GetMapping("/majors")
+    public ResponseForm<MajorsResponse> getMajors(
+            @RequestParam(value = "universityName") String universityName,
+            @RequestParam(value = "largeClass") String largeClass
+    ) {
+        return new ResponseForm<>(assetService.getMajorsByClassAndName(universityName, largeClass));
+    }
+}

--- a/src/main/java/com/flint/flint/config/SecurityConfig.java
+++ b/src/main/java/com/flint/flint/config/SecurityConfig.java
@@ -31,10 +31,15 @@ public class SecurityConfig {
                 .httpBasic(httpBasic -> httpBasic.disable())
 
                 .authorizeRequests(authorizeRequests -> authorizeRequests
-                        .requestMatchers("/api/v1/auth/**", "/api/v1/mail/**").permitAll()
-                        .requestMatchers("/api/v1/idcard/**").hasRole("AUTHUSER") //"ROLE_" 자동으로 붙여줘
+                        .requestMatchers(
+                                "/api/v1/auth/**",
+                                "/api/v1/mail/**",
+                                "/api/v1/assets",
+                                "/api/v1/boards").permitAll()
+                        .requestMatchers(
+                                "/api/v1/idcard/**").hasRole("AUTHUSER") //"ROLE_" 자동으로 붙여줘
                 )
-                .exceptionHandling(exceptionHandling -> exceptionHandling.authenticationEntryPoint(jwtAuthenticationEntryPoint)) ;
+                .exceptionHandling(exceptionHandling -> exceptionHandling.authenticationEntryPoint(jwtAuthenticationEntryPoint));
 
         http.addFilterBefore(new JwtAuthenticationFilter(jwtService), UsernamePasswordAuthenticationFilter.class);
         return http.build();

--- a/src/main/java/com/flint/flint/security/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/flint/flint/security/auth/jwt/JwtAuthenticationFilter.java
@@ -23,7 +23,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
 
-        if (request.getServletPath().contains("/api/v1/auth")) {
+        if (request.getServletPath().contains("/api/v1/auth") ||
+                request.getServletPath().contains("/api/v1/assets")) {
             filterChain.doFilter(request, response);
             return;
         }

--- a/src/test/java/com/flint/flint/asset/controller/AssetApiControllerTest.java
+++ b/src/test/java/com/flint/flint/asset/controller/AssetApiControllerTest.java
@@ -1,0 +1,225 @@
+package com.flint.flint.asset.controller;
+
+import com.flint.flint.asset.domain.UniversityAsset;
+import com.flint.flint.asset.domain.UniversityMajor;
+import com.flint.flint.asset.repository.UniversityAssetRepository;
+import com.flint.flint.asset.repository.UniversityMajorRepository;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class AssetApiControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private UniversityAssetRepository assetRepository;
+    @Autowired
+    private UniversityMajorRepository majorRepository;
+    private static final String BASE_URL = "/api/v1/assets";
+
+    @BeforeEach
+    void init() {
+        UniversityAsset asset = UniversityAsset.builder()
+                .universityName("가천대학교")
+                .emailSuffix("gachon.ac.kr")
+                .red(8)
+                .green(56)
+                .blue(136)
+                .logoUrl("/가천")
+                .build();
+
+        UniversityAsset asset2 = UniversityAsset.builder()
+                .universityName("중앙대학교")
+                .emailSuffix("cau.ac.kr")
+                .red(155)
+                .green(44)
+                .blue(53)
+                .logoUrl("/중앙")
+                .build();
+
+        UniversityAsset asset3 = UniversityAsset.builder()
+                .universityName("한양대학교")
+                .emailSuffix("hanyang.ac.kr")
+                .red(71)
+                .green(47)
+                .blue(145)
+                .logoUrl("/한양")
+                .build();
+
+        UniversityAsset asset4 = UniversityAsset.builder()
+                .universityName("한양대학교(ERICA)")
+                .emailSuffix("hanyang.ac.kr")
+                .red(4)
+                .green(52)
+                .blue(134)
+                .logoUrl("/한양(ERICA)")
+                .build();
+
+        assetRepository.save(asset);
+        assetRepository.save(asset2);
+        assetRepository.save(asset3);
+        assetRepository.save(asset4);
+
+
+        UniversityMajor major = UniversityMajor.builder()
+                .universityName("가천대학교")
+                .largeClass("공학계열")
+                .mediumClass("a")
+                .smallClass("b")
+                .majorName("전기공학과")
+                .build();
+        UniversityMajor major2 = UniversityMajor.builder()
+                .universityName("가천대학교")
+                .largeClass("공학계열")
+                .mediumClass("a")
+                .smallClass("b")
+                .majorName("신소재공학과")
+                .build();
+        UniversityMajor major3 = UniversityMajor.builder()
+                .universityName("가천대학교")
+                .largeClass("공학계열")
+                .mediumClass("a")
+                .smallClass("b")
+                .majorName("컴퓨터공학부(컴퓨터공학전공)")
+                .build();
+
+        UniversityMajor major4 = UniversityMajor.builder()
+                .universityName("가천대학교")
+                .largeClass("인문사회계열")
+                .mediumClass("a")
+                .smallClass("b")
+                .majorName("영어교육과")
+                .build();
+        UniversityMajor major5 = UniversityMajor.builder()
+                .universityName("가천대학교")
+                .largeClass("인문사회계열")
+                .mediumClass("a")
+                .smallClass("b")
+                .majorName("경영학전공")
+                .build();
+        UniversityMajor major6 = UniversityMajor.builder()
+                .universityName("가천대학교")
+                .largeClass("인문사회계열")
+                .mediumClass("a")
+                .smallClass("b")
+                .majorName("사회복지학전공")
+                .build();
+
+        majorRepository.save(major);
+        majorRepository.save(major2);
+        majorRepository.save(major3);
+        majorRepository.save(major4);
+        majorRepository.save(major5);
+        majorRepository.save(major6);
+    }
+
+    @Test
+    @DisplayName("학교 이름으로 학교 로고 정보를 조회한다.")
+    void getUniversityLogo() throws Exception {
+        MvcResult mvcResult = this.mockMvc.perform(get(BASE_URL + "/logo/{universityName}", "가천대학교"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JSONObject data = extractPayload(mvcResult);
+
+        assertEquals("/가천", data.optString("logoUrl"));
+        assertEquals(8, data.optInt("red"));
+        assertEquals(56, data.optInt("green"));
+        assertEquals(136, data.optInt("blue"));
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 대학교 이름으로 로고 조회 시 예외가 발생한다.")
+    void getLogoWithException() throws Exception {
+        MvcResult mvcResult = this.mockMvc.perform(
+                        get(BASE_URL + "/logo/{universityName}", "뚫꿇대학교")
+                ).andExpect(status().is4xxClientError())
+                .andReturn();
+
+        JSONObject status = extractStatus(mvcResult);
+
+        assertEquals("F700", status.optString("resultCode"));
+    }
+
+    @Test
+    @DisplayName("학교 이름으로 학교 이메일 정보를 조회한다.")
+    void getUniversityEmail() throws Exception {
+        MvcResult mvcResult = this.mockMvc.perform(get(BASE_URL + "/email/{universityName}", "가천대학교"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JSONObject data = extractPayload(mvcResult);
+
+        assertEquals("gachon.ac.kr", data.optString("emailSuffix"));
+    }
+
+    @Test
+    @DisplayName("전체 학교 목록을 조회한다.")
+    void getUniversities() throws Exception {
+        MvcResult mvcResult = this.mockMvc.perform(get(BASE_URL + "/universities"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JSONObject json = new JSONObject(mvcResult.getResponse().getContentAsString(StandardCharsets.UTF_8));
+        JSONArray jsonArray = json.optJSONArray("data");
+        assertEquals(4, jsonArray.length());
+    }
+
+    @Test
+    @DisplayName("학교 이름으로 해당 학교의 전공 대분류 목록을 중복 없이 조회한다.")
+    void getLargeClasses() throws Exception {
+        MvcResult mvcResult = this.mockMvc.perform(get(BASE_URL + "/majors/large-class/{universityName}", "가천대학교"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JSONObject json = new JSONObject(mvcResult.getResponse().getContentAsString(StandardCharsets.UTF_8));
+        JSONArray jsonArray = json.optJSONArray("data");
+
+        assertEquals(2, jsonArray.length());
+        assertEquals("공학계열", jsonArray.getString(0));
+        assertEquals("인문사회계열", jsonArray.getString(1));
+    }
+
+    @Test
+    @DisplayName("학교 이름과 전공 대분류로 전공 이름 기준 오름차순으로 전공 목록을 조회한다.")
+    void getMajors() throws Exception {
+        MvcResult mvcResult = this.mockMvc.perform(get(BASE_URL + "/majors")
+                        .param("universityName", "가천대학교")
+                        .param("largeClass", "공학계열"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JSONObject data = extractPayload(mvcResult);
+
+        assertEquals(3, data.optJSONArray("majors").length());
+        assertEquals("신소재공학과", data.optJSONArray("majors").getString(0));
+    }
+
+    private JSONObject extractStatus(MvcResult mvcResult) throws Exception {
+        JSONObject json = new JSONObject(mvcResult.getResponse().getContentAsString(StandardCharsets.UTF_8));
+        return json.optJSONObject("statusResponse");
+    }
+
+    private JSONObject extractPayload(MvcResult mvcResult) throws Exception {
+        JSONObject json = new JSONObject(mvcResult.getResponse().getContentAsString(StandardCharsets.UTF_8));
+        return json.optJSONObject("data");
+    }
+}


### PR DESCRIPTION
## 관련 이슈
close #47 
## 변경사항
- Asset 데이터 조회하는 서비스 로직을 API화하여 컨트롤러를 구현하였습니다.
  - 학교 로고 조회 API
  - 학교 이메일 조회 API
  - 대학교 목록 조회 API
  - 대분류 목록 조회 API
  - 전공 목록 조회 API
- Asset API와 Board API에 대해 Jwt 필터와 Security 권한 처리에서 제외하였습니다.
- Asset API에 대해 Mocking 테스트를 수행
## 개발하면서 발생한 문제점과 해결방안 또는 새롭게 알게된 점
- 테스트 돌리던 중 글로벌 예외 핸들러에 의해 발생한 예외처리 메세지가 나왔는데 테스트가 성공해서 당황했는데 알고보니 예외 테스트할 때 throw한 결과가 글로벌 예외 핸들러 메소드가 캐치한 로그 출력이였다.
## 당부하고 싶은 말 또는 논의해봐야할 점
x
## 스크린샷
![image](https://github.com/Flint-org/Flint-API-Server/assets/54919474/85f5eba6-c0e0-4e32-bc89-b1d510476325)

## 기타 및 추후 계획
- Asset은 종료!

