### PR TITLE
자신 명함 조회 API

### DIFF
--- a/src/main/java/com/flint/flint/config/SecurityConfig.java
+++ b/src/main/java/com/flint/flint/config/SecurityConfig.java
@@ -30,7 +30,7 @@ public class SecurityConfig {
                 .formLogin(formLogin -> formLogin.disable())
                 .httpBasic(httpBasic -> httpBasic.disable())
 
-                .authorizeRequests(authorizeRequests -> authorizeRequests
+                .authorizeHttpRequests(authorizeRequests -> authorizeRequests
                         .requestMatchers("/api/v1/auth/**", "/api/v1/mail/**").permitAll()
                         .requestMatchers("/api/v1/idcard/**").hasRole("AUTHUSER") //"ROLE_" 자동으로 붙여줘
                 )

--- a/src/main/java/com/flint/flint/idcard/controller/IdCardGetController.java
+++ b/src/main/java/com/flint/flint/idcard/controller/IdCardGetController.java
@@ -6,7 +6,7 @@ import com.flint.flint.idcard.service.IdCardService;
 import com.flint.flint.security.auth.dto.AuthorityMemberDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,7 +22,7 @@ public class IdCardGetController {
 
     private final IdCardService idCardService;
 
-    @PostMapping("/mine")
+    @GetMapping("/mine")
     public ResponseForm<IdCardGetResponse.MyIdCard> getMyIdCard(@AuthenticationPrincipal AuthorityMemberDTO authorityMemberDTO) {
         Long id = authorityMemberDTO.getId();
         return new ResponseForm<>(idCardService.getMyIdCardByMemberId(id));

--- a/src/main/java/com/flint/flint/idcard/controller/IdCardGetController.java
+++ b/src/main/java/com/flint/flint/idcard/controller/IdCardGetController.java
@@ -1,0 +1,30 @@
+package com.flint.flint.idcard.controller;
+
+import com.flint.flint.common.ResponseForm;
+import com.flint.flint.idcard.dto.response.IdCardGetResponse;
+import com.flint.flint.idcard.service.IdCardService;
+import com.flint.flint.security.auth.dto.AuthorityMemberDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+/**
+ * @author 정순원
+ * @since 2023-09-12
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1/idcard")
+public class IdCardGetController {
+
+    private final IdCardService idCardService;
+
+    @PostMapping("/my")
+    public ResponseForm<IdCardGetResponse.MyIdCard> getMyIdCard(@AuthenticationPrincipal AuthorityMemberDTO authorityMemberDTO) {
+        Long id = authorityMemberDTO.getId();
+        return new ResponseForm<>(idCardService.findMyIdCardByMemberId(id));
+    }
+}

--- a/src/main/java/com/flint/flint/idcard/controller/IdCardGetController.java
+++ b/src/main/java/com/flint/flint/idcard/controller/IdCardGetController.java
@@ -22,9 +22,9 @@ public class IdCardGetController {
 
     private final IdCardService idCardService;
 
-    @PostMapping("/my")
+    @PostMapping("/mine")
     public ResponseForm<IdCardGetResponse.MyIdCard> getMyIdCard(@AuthenticationPrincipal AuthorityMemberDTO authorityMemberDTO) {
         Long id = authorityMemberDTO.getId();
-        return new ResponseForm<>(idCardService.findMyIdCardByMemberId(id));
+        return new ResponseForm<>(idCardService.getMyIdCardByMemberId(id));
     }
 }

--- a/src/main/java/com/flint/flint/idcard/dto/response/IdCardGetResponse.java
+++ b/src/main/java/com/flint/flint/idcard/dto/response/IdCardGetResponse.java
@@ -1,11 +1,9 @@
 package com.flint.flint.idcard.dto.response;
 
+import com.flint.flint.asset.dto.LogoInfoResponse;
 import com.flint.flint.idcard.domain.IdCard;
 import com.flint.flint.idcard.spec.InterestType;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.List;
 
@@ -15,10 +13,11 @@ import java.util.List;
  */
 public class IdCardGetResponse {
 
-    @Getter
+    @Data
     @NoArgsConstructor
     @AllArgsConstructor
     public static class MyIdCard {
+        private LogoInfoResponse univInfo; // 대학 로고, 이름, 전공
         private Long id;
         private int admissionYear;
         private String university;
@@ -28,8 +27,9 @@ public class IdCardGetResponse {
         private String cardBackMBTI;
         private List<InterestType> cardBackInterestTypeList;
 
-        public static MyIdCard of(IdCard idCard) {
+        public static MyIdCard of(LogoInfoResponse univInfo, IdCard idCard) {
             return new MyIdCard(
+                    univInfo,
                     idCard.getId(),
                     idCard.getAdmissionYear(),
                     idCard.getUniversity(),

--- a/src/main/java/com/flint/flint/idcard/dto/response/IdCardGetResponse.java
+++ b/src/main/java/com/flint/flint/idcard/dto/response/IdCardGetResponse.java
@@ -1,0 +1,44 @@
+package com.flint.flint.idcard.dto.response;
+
+import com.flint.flint.idcard.domain.IdCard;
+import com.flint.flint.idcard.spec.InterestType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * @author 정순원
+ * @since 2023-09-10
+ */
+public class IdCardGetResponse {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MyIdCard {
+        private Long id;
+        private int admissionYear;
+        private String university;
+        private String major;
+        private String cardBackIntroduction;
+        private String cardBackSNSId;
+        private String cardBackMBTI;
+        private List<InterestType> cardBackInterestTypeList;
+
+        public static MyIdCard of(IdCard idCard) {
+            return new MyIdCard(
+                    idCard.getId(),
+                    idCard.getAdmissionYear(),
+                    idCard.getUniversity(),
+                    idCard.getMajor(),
+                    idCard.getCardBackIntroduction(),
+                    idCard.getCardBackSNSId(),
+                    idCard.getCardBackMBTI(),
+                    idCard.getCardBackInterestTypeList()
+            );
+        }
+    }
+}

--- a/src/main/java/com/flint/flint/idcard/dto/response/IdCardResponse.java
+++ b/src/main/java/com/flint/flint/idcard/dto/response/IdCardResponse.java
@@ -1,8 +1,0 @@
-package com.flint.flint.idcard.dto.response;
-
-/**
- * @author 정순원
- * @since 2023-09-10
- */
-public class IdCardResponse {
-}

--- a/src/main/java/com/flint/flint/idcard/repository/IdCardJPARepository.java
+++ b/src/main/java/com/flint/flint/idcard/repository/IdCardJPARepository.java
@@ -1,11 +1,16 @@
 package com.flint.flint.idcard.repository;
 
 import com.flint.flint.idcard.domain.IdCard;
+import com.flint.flint.member.domain.main.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
 
 /**
  * @author 정순원
  * @since 2023-09-10
  */
 public interface IdCardJPARepository extends JpaRepository<IdCard, Long>, IdcardRepositoryCustom {
+
+    Optional<IdCard> findByMember(Member member);
 }

--- a/src/main/java/com/flint/flint/idcard/service/IdCardService.java
+++ b/src/main/java/com/flint/flint/idcard/service/IdCardService.java
@@ -1,5 +1,7 @@
 package com.flint.flint.idcard.service;
 
+import com.flint.flint.asset.dto.LogoInfoResponse;
+import com.flint.flint.asset.service.AssetService;
 import com.flint.flint.common.exception.FlintCustomException;
 import com.flint.flint.common.spec.ResultCode;
 import com.flint.flint.idcard.dto.request.IdCardRequest;
@@ -28,6 +30,7 @@ public class IdCardService {
 
     private final IdCardJPARepository idCardJPARepository;
     private final MemberService memberService;
+    private final AssetService assetService;
 
     @Transactional
     public void saveFrontIdCard(Member member, SuccessUniversityAuthRequest request) {
@@ -47,11 +50,11 @@ public class IdCardService {
         List<InterestType> cardBackInterestTypeList = request.getCardBackInterestTypeList();
         String cardBackIntroduction = request.getCardBackIntroduction();
 
-        IdCard idCard = findIdCardById(IdCardId);
+        IdCard idCard = getIdCardById(IdCardId);
         idCard.updateBack(cardBackIntroduction, cardBackMBTI, cardBackSNSId, cardBackInterestTypeList);
     }
 
-    private IdCard findIdCardById(Long idCardId) {
+    private IdCard getIdCardById(Long idCardId) {
         return idCardJPARepository.findById(idCardId).orElseThrow(() -> new FlintCustomException(HttpStatus.NOT_FOUND, ResultCode.IDCARD_NOT_FOUND));
     }
 
@@ -59,9 +62,12 @@ public class IdCardService {
      * 자신 명함 조회
      */
     @Transactional
-    public IdCardGetResponse.MyIdCard findMyIdCardByMemberId(Long memberId) {
+    public IdCardGetResponse.MyIdCard getMyIdCardByMemberId(Long memberId) {
         Member member = memberService.getMember(memberId);
         IdCard idCard = idCardJPARepository.findByMember(member).orElseThrow(() -> new FlintCustomException(HttpStatus.BAD_REQUEST, ResultCode.IDCARD_NOT_FOUND));
-        return  IdCardGetResponse.MyIdCard.of(idCard);
+        String university = idCard.getUniversity();
+        LogoInfoResponse univInfo = assetService.getUniversityLogoInfoByName(university);
+
+        return  IdCardGetResponse.MyIdCard.of(univInfo, idCard);
     }
 }

--- a/src/main/java/com/flint/flint/idcard/service/IdCardService.java
+++ b/src/main/java/com/flint/flint/idcard/service/IdCardService.java
@@ -3,11 +3,13 @@ package com.flint.flint.idcard.service;
 import com.flint.flint.common.exception.FlintCustomException;
 import com.flint.flint.common.spec.ResultCode;
 import com.flint.flint.idcard.dto.request.IdCardRequest;
+import com.flint.flint.idcard.dto.response.IdCardGetResponse;
 import com.flint.flint.idcard.spec.InterestType;
 import com.flint.flint.mail.dto.request.SuccessUniversityAuthRequest;
 import com.flint.flint.idcard.domain.IdCard;
 import com.flint.flint.member.domain.main.Member;
 import com.flint.flint.idcard.repository.IdCardJPARepository;
+import com.flint.flint.member.service.MemberService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -25,6 +27,7 @@ import java.util.List;
 public class IdCardService {
 
     private final IdCardJPARepository idCardJPARepository;
+    private final MemberService memberService;
 
     @Transactional
     public void saveFrontIdCard(Member member, SuccessUniversityAuthRequest request) {
@@ -44,11 +47,21 @@ public class IdCardService {
         List<InterestType> cardBackInterestTypeList = request.getCardBackInterestTypeList();
         String cardBackIntroduction = request.getCardBackIntroduction();
 
-        IdCard idCard = getIdCard(IdCardId);
+        IdCard idCard = findIdCardById(IdCardId);
         idCard.updateBack(cardBackIntroduction, cardBackMBTI, cardBackSNSId, cardBackInterestTypeList);
     }
 
-    private IdCard getIdCard(Long idCardId) {
+    private IdCard findIdCardById(Long idCardId) {
         return idCardJPARepository.findById(idCardId).orElseThrow(() -> new FlintCustomException(HttpStatus.NOT_FOUND, ResultCode.IDCARD_NOT_FOUND));
+    }
+
+    /**
+     * 자신 명함 조회
+     */
+    @Transactional
+    public IdCardGetResponse.MyIdCard findMyIdCardByMemberId(Long memberId) {
+        Member member = memberService.getMember(memberId);
+        IdCard idCard = idCardJPARepository.findByMember(member).orElseThrow(() -> new FlintCustomException(HttpStatus.BAD_REQUEST, ResultCode.IDCARD_NOT_FOUND));
+        return  IdCardGetResponse.MyIdCard.of(idCard);
     }
 }

--- a/src/main/java/com/flint/flint/idcard/spec/InterestConverter.java
+++ b/src/main/java/com/flint/flint/idcard/spec/InterestConverter.java
@@ -40,7 +40,7 @@ public class InterestConverter implements AttributeConverter<List<InterestType>,
     @Override
     public List<InterestType> convertToEntityAttribute(String dbData) {
         if (Strings.isEmpty(dbData)) {
-            return new ArrayList<>();
+            return null;
         }
 
         List<InterestType> interestTypeList = Arrays.stream(dbData.split(DELIMITER))

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,11 +6,11 @@ spring:
     driver-class-name: org.h2.Driver
     url: jdbc:h2:mem:test;MODE=MySQL;
     username: sa
-    password: 1234
+    password:
 
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: create
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
## 관련 이슈
close #52 
## 변경사항
- 자신명함 조회 API 정의
- 자신 명함 조회 service 정의
- 자신 명함 조회 service 테스트
- InterestTypeList 컨버터
  -  값이 없는 InterestTypeList 를 디비에 저장할 때는 null로 꺼내올 때는 빈 ArrayList를 리턴하도록 구현했었는데, 통일성이 어긋나다 생각하여 꺼내올 때도 null를 리턴하도록 구현
## 개발하면서 발생한 문제점과 해결방안 또는 새롭게 알게된 점
- 명함을 조회하는 컨트롤러와 서비스 안에 메소드 명명에 대한 고민
    > controller에서 HTTP 행위 기준으로 명명한다. 
       servive에서는 비지니스 로직 행위 기준으로 명명 한다
       
 - 서비스에서 DTO를 파라미터로 받는 게 아니라 Controller에서 DTO 가공해서 넘겨주려고 함(역활 분리를 위해서 한 건데 어떤 점이 좋은지 명확하지 않아서 좀 더 공부해봐야 할 것 같아요)
- 단위테스트 성공 통합테스트 실패 이유
 >  !롤백이 되더라도 전에 사용하던 id sequence 값은 유지된다!
   
## 당부하고 싶은 말 또는 논의해봐야할 점
오늘 자신명함조회 API 빠르게 끝내고 명함 박스 API 구현하려고 했는데 ,
테스트 실패의 원인을 찾아내려고 많은 시간을 써서 명함 박스 API 구현 시작도 못했습니다..
## 스크린샷
![image](https://github.com/Flint-org/Flint-API-Server/assets/92251131/832aaae4-f766-43ca-a3a8-271afc58f1dc)

## 기타 및 추후 계획
- 명함박스 관련 API 구현
- springbootTest 로딩이 너무 오래 걸려 Mock에 대한 공부
