### PR TITLE
Feat: 명함박스,폴더 API

### DIFF
--- a/src/main/java/com/flint/flint/common/spec/ResultCode.java
+++ b/src/main/java/com/flint/flint/common/spec/ResultCode.java
@@ -59,7 +59,8 @@ public enum ResultCode {
     NOT_VALIDATION("F800", "json 값이 올바르지 않습니다."),
 
     // F9xx: 명함 예외
-    IDCARD_NOT_FOUND("F900", "명함을 찾을 수 없습니다.");
+    IDCARD_NOT_FOUND("F900", "명함을 찾을 수 없습니다."),
+    IDCARDBOX_NOT_FOUND("F901","유저가 이 명함을 가지고 있지 않습니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/flint/flint/config/SecurityConfig.java
+++ b/src/main/java/com/flint/flint/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import com.flint.flint.security.auth.jwt.JwtService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -32,11 +33,13 @@ public class SecurityConfig {
 
                 .authorizeHttpRequests(authorizeRequests -> authorizeRequests
                         .requestMatchers("/api/v1/auth/**",
-                                         "/api/v1/mail/**",
-                                         "/api/v1/assets",
-                                         "/api/v1/boards"
-                                        ).permitAll()
+                                "/api/v1/mail/**",
+                                "/api/v1/assets/**",
+                                "/api/v1/boards/**").permitAll()
                         .requestMatchers("/api/v1/idcard/**").hasRole("AUTHUSER") //"ROLE_"  PREFIX 자동으로 붙여줍니다
+                        .requestMatchers(HttpMethod.POST, "/api/v1/clubs/**" ).hasRole("AUTHUSER")
+                        .requestMatchers(HttpMethod.GET, "/api/v1/clubs/**").permitAll()
+                        .anyRequest().authenticated()
                 )
 
                 .exceptionHandling(exceptionHandling -> exceptionHandling.authenticationEntryPoint(jwtAuthenticationEntryPoint));

--- a/src/main/java/com/flint/flint/config/SecurityConfig.java
+++ b/src/main/java/com/flint/flint/config/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig {
                                         ).permitAll()
                         .requestMatchers("/api/v1/idcard/**").hasRole("AUTHUSER") //"ROLE_"  PREFIX 자동으로 붙여줍니다
                 )
-          
+
                 .exceptionHandling(exceptionHandling -> exceptionHandling.authenticationEntryPoint(jwtAuthenticationEntryPoint));
 
         http.addFilterBefore(new JwtAuthenticationFilter(jwtService), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/flint/flint/idcard/controller/IdCardBoxUpdateController.java
+++ b/src/main/java/com/flint/flint/idcard/controller/IdCardBoxUpdateController.java
@@ -1,10 +1,8 @@
 package com.flint.flint.idcard.controller;
 
 import com.flint.flint.common.ResponseForm;
-import com.flint.flint.idcard.dto.request.IdCardRequest;
 import com.flint.flint.idcard.service.IdCardBoxService;
 import com.flint.flint.security.auth.dto.AuthorityMemberDTO;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -16,10 +14,10 @@ public class IdCardBoxUpdateController {
 
     private final IdCardBoxService idCardBoxService;
 
-    @PostMapping("/other/{idCardId}")
-    public ResponseForm saveIdCardBox (@PathVariable Long idCardId, @AuthenticationPrincipal AuthorityMemberDTO memberDTO) {
+    @PostMapping("/{idCardId}")
+    public ResponseForm createIdCardBox (@PathVariable Long idCardId, @AuthenticationPrincipal AuthorityMemberDTO memberDTO) {
         Long memberId = memberDTO.getId();
-        idCardBoxService.saveIdCardBox(idCardId, memberId);
+        idCardBoxService.createIdCardBox(idCardId, memberId);
         return new ResponseForm<>();
     }
 }

--- a/src/main/java/com/flint/flint/idcard/controller/IdCardBoxUpdateController.java
+++ b/src/main/java/com/flint/flint/idcard/controller/IdCardBoxUpdateController.java
@@ -20,4 +20,11 @@ public class IdCardBoxUpdateController {
         idCardBoxService.createIdCardBox(idCardId, memberId);
         return new ResponseForm<>();
     }
+
+    @DeleteMapping("/{idCardId}")
+    public ResponseForm removeIdCardBox (@PathVariable Long idCardId, @AuthenticationPrincipal AuthorityMemberDTO memberDTO) {
+        Long memberId = memberDTO.getId();
+        idCardBoxService.removeIdCardBox(idCardId, memberId);
+        return new ResponseForm<>();
+    }
 }

--- a/src/main/java/com/flint/flint/idcard/controller/IdCardBoxUpdateController.java
+++ b/src/main/java/com/flint/flint/idcard/controller/IdCardBoxUpdateController.java
@@ -1,0 +1,25 @@
+package com.flint.flint.idcard.controller;
+
+import com.flint.flint.common.ResponseForm;
+import com.flint.flint.idcard.dto.request.IdCardRequest;
+import com.flint.flint.idcard.service.IdCardBoxService;
+import com.flint.flint.security.auth.dto.AuthorityMemberDTO;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1/idcard/box")
+public class IdCardBoxUpdateController {
+
+    private final IdCardBoxService idCardBoxService;
+
+    @PostMapping("/other/{idCardId}")
+    public ResponseForm saveIdCardBox (@PathVariable Long idCardId, @AuthenticationPrincipal AuthorityMemberDTO memberDTO) {
+        Long memberId = memberDTO.getId();
+        idCardBoxService.saveIdCardBox(idCardId, memberId);
+        return new ResponseForm<>();
+    }
+}

--- a/src/main/java/com/flint/flint/idcard/controller/IdCardFolderUpdateController.java
+++ b/src/main/java/com/flint/flint/idcard/controller/IdCardFolderUpdateController.java
@@ -1,0 +1,27 @@
+package com.flint.flint.idcard.controller;
+
+import com.flint.flint.common.ResponseForm;
+import com.flint.flint.idcard.dto.request.IdCardFolderUpdateRequest;
+import com.flint.flint.idcard.service.IdCardFolderService;
+import com.flint.flint.security.auth.dto.AuthorityMemberDTO;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1/idcard/box/folder")
+public class IdCardFolderUpdateController {
+
+    private final IdCardFolderService idCardFolderService;
+
+    @PostMapping
+    public ResponseForm createIdCardFolder (@Valid @RequestBody IdCardFolderUpdateRequest.CreateFolderRequest requestBody,
+                                            @AuthenticationPrincipal AuthorityMemberDTO memberDTO) {
+        return new ResponseForm<>(idCardFolderService.createIdCardFolder(requestBody.getTitle(), memberDTO.getId()));
+    }
+}

--- a/src/main/java/com/flint/flint/idcard/controller/IdCardGetController.java
+++ b/src/main/java/com/flint/flint/idcard/controller/IdCardGetController.java
@@ -22,7 +22,7 @@ public class IdCardGetController {
 
     private final IdCardService idCardService;
 
-    @GetMapping("/mine")
+    @GetMapping
     public ResponseForm<IdCardGetResponse.MyIdCard> getMyIdCard(@AuthenticationPrincipal AuthorityMemberDTO authorityMemberDTO) {
         Long id = authorityMemberDTO.getId();
         return new ResponseForm<>(idCardService.getMyIdCardByMemberId(id));

--- a/src/main/java/com/flint/flint/idcard/domain/IdCardBox.java
+++ b/src/main/java/com/flint/flint/idcard/domain/IdCardBox.java
@@ -7,6 +7,9 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.Length;
+
+import java.util.List;
 
 /**
  * @Author 정순원
@@ -22,18 +25,25 @@ public class IdCardBox extends BaseTimeEntity {
     @Column(name = "id_card_box_id")
     private Long id;
 
+    @Column(length = 100)
+    private String folder;
+
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "club_id")
-    private Club club;
+    @JoinColumn(name = "id_card_id")
+    private IdCard idcard;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
     @Builder
-    public IdCardBox(Club club, Member member) {
-        this.club = club;
+    public IdCardBox(IdCard idcard, Member member) {
+        this.idcard = idcard;
         this.member = member;
+    }
+
+    public void updateFolder(String folder) {
+        this.folder = folder;
     }
 
 }

--- a/src/main/java/com/flint/flint/idcard/domain/IdCardBox.java
+++ b/src/main/java/com/flint/flint/idcard/domain/IdCardBox.java
@@ -27,15 +27,15 @@ public class IdCardBox extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "id_card_id")
-    private IdCard idcard;
+    private IdCard idCard;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
     @Builder
-    public IdCardBox(IdCard idcard, Member member) {
-        this.idcard = idcard;
+    public IdCardBox(IdCard idCard, Member member) {
+        this.idCard = idCard;
         this.member = member;
     }
 }

--- a/src/main/java/com/flint/flint/idcard/domain/IdCardFolder.java
+++ b/src/main/java/com/flint/flint/idcard/domain/IdCardFolder.java
@@ -1,29 +1,28 @@
 package com.flint.flint.idcard.domain;
 
-import com.flint.flint.club.domain.main.Club;
 import com.flint.flint.common.BaseTimeEntity;
 import com.flint.flint.member.domain.main.Member;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.Length;
-
-import java.util.List;
 
 /**
- * @Author 정순원
- * @Since 2023-08-07
+ * @author 정순원
+ * @since 2023-09-14
  */
 @Entity
 @Getter
 @NoArgsConstructor
-public class IdCardBox extends BaseTimeEntity {
+public class IdCardFolder extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id_card_box_id")
+    @Column(name = "id_card_folder_id")
     private Long id;
+
+    @Column(length = 50)
+    private String title;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "id_card_id")
@@ -34,7 +33,8 @@ public class IdCardBox extends BaseTimeEntity {
     private Member member;
 
     @Builder
-    public IdCardBox(IdCard idcard, Member member) {
+    public IdCardFolder(String title, IdCard idcard, Member member) {
+        this.title = title;
         this.idcard = idcard;
         this.member = member;
     }

--- a/src/main/java/com/flint/flint/idcard/domain/IdCardFolder.java
+++ b/src/main/java/com/flint/flint/idcard/domain/IdCardFolder.java
@@ -26,16 +26,16 @@ public class IdCardFolder extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "id_card_id")
-    private IdCard idcard;
+    private IdCard idCard;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
     @Builder
-    public IdCardFolder(String title, IdCard idcard, Member member) {
+    public IdCardFolder(String title, IdCard idCard, Member member) {
         this.title = title;
-        this.idcard = idcard;
+        this.idCard = idCard;
         this.member = member;
     }
 }

--- a/src/main/java/com/flint/flint/idcard/dto/request/IdCardFolderUpdateRequest.java
+++ b/src/main/java/com/flint/flint/idcard/dto/request/IdCardFolderUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.flint.flint.idcard.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+public class IdCardFolderUpdateRequest {
+
+    @Data
+    @AllArgsConstructor
+    public static class CreateFolderRequest {
+
+        @NotBlank
+        private String title;
+    }
+
+}

--- a/src/main/java/com/flint/flint/idcard/dto/response/IdCardFolderUpdateResponse.java
+++ b/src/main/java/com/flint/flint/idcard/dto/response/IdCardFolderUpdateResponse.java
@@ -1,0 +1,14 @@
+package com.flint.flint.idcard.dto.response;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+public class IdCardFolderUpdateResponse {
+
+    @Data
+    @AllArgsConstructor
+    public static class CreateIdCardFolderResponse {
+        private long folderId;
+    }
+}

--- a/src/main/java/com/flint/flint/idcard/dto/response/IdCardGetResponse.java
+++ b/src/main/java/com/flint/flint/idcard/dto/response/IdCardGetResponse.java
@@ -3,7 +3,9 @@ package com.flint.flint.idcard.dto.response;
 import com.flint.flint.asset.dto.LogoInfoResponse;
 import com.flint.flint.idcard.domain.IdCard;
 import com.flint.flint.idcard.spec.InterestType;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 

--- a/src/main/java/com/flint/flint/idcard/repository/IdCardBoxJPARepository.java
+++ b/src/main/java/com/flint/flint/idcard/repository/IdCardBoxJPARepository.java
@@ -1,7 +1,15 @@
 package com.flint.flint.idcard.repository;
 
+import com.flint.flint.idcard.domain.IdCard;
 import com.flint.flint.idcard.domain.IdCardBox;
+import com.flint.flint.member.domain.main.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface IdCardBoxJPARepository extends JpaRepository<IdCardBox, Long> {
+
+    void deleteByMemberAndIdCard(Member member, IdCard idCard);
+
+
 }

--- a/src/main/java/com/flint/flint/idcard/repository/IdCardBoxJPARepository.java
+++ b/src/main/java/com/flint/flint/idcard/repository/IdCardBoxJPARepository.java
@@ -1,0 +1,7 @@
+package com.flint.flint.idcard.repository;
+
+import com.flint.flint.idcard.domain.IdCardBox;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface IdCardBoxJPARepository extends JpaRepository<IdCardBox, Long> {
+}

--- a/src/main/java/com/flint/flint/idcard/repository/IdCardFolderJPARepository.java
+++ b/src/main/java/com/flint/flint/idcard/repository/IdCardFolderJPARepository.java
@@ -3,5 +3,7 @@ package com.flint.flint.idcard.repository;
 import com.flint.flint.idcard.domain.IdCardFolder;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface IdCardInFolderJPARepository extends JpaRepository<IdCardFolder, Long> {
+import java.util.Optional;
+
+public interface IdCardFolderJPARepository extends JpaRepository<IdCardFolder, Long> {
 }

--- a/src/main/java/com/flint/flint/idcard/repository/IdCardInFolderJPARepository.java
+++ b/src/main/java/com/flint/flint/idcard/repository/IdCardInFolderJPARepository.java
@@ -1,0 +1,7 @@
+package com.flint.flint.idcard.repository;
+
+import com.flint.flint.idcard.domain.IdCardFolder;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface IdCardInFolderJPARepository extends JpaRepository<IdCardFolder, Long> {
+}

--- a/src/main/java/com/flint/flint/idcard/repository/IdCardJPARepository.java
+++ b/src/main/java/com/flint/flint/idcard/repository/IdCardJPARepository.java
@@ -1,6 +1,7 @@
 package com.flint.flint.idcard.repository;
 
 import com.flint.flint.idcard.domain.IdCard;
+import com.flint.flint.idcard.repository.custom.IdcardRepositoryCustom;
 import com.flint.flint.member.domain.main.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/com/flint/flint/idcard/repository/custom/IdcardRepositoryCustom.java
+++ b/src/main/java/com/flint/flint/idcard/repository/custom/IdcardRepositoryCustom.java
@@ -1,4 +1,4 @@
-package com.flint.flint.idcard.repository;
+package com.flint.flint.idcard.repository.custom;
 
 /**
  * @author 정순원

--- a/src/main/java/com/flint/flint/idcard/repository/impl/IdCardRepositoryImpl.java
+++ b/src/main/java/com/flint/flint/idcard/repository/impl/IdCardRepositoryImpl.java
@@ -1,5 +1,6 @@
-package com.flint.flint.idcard.repository;
+package com.flint.flint.idcard.repository.impl;
 
+import com.flint.flint.idcard.repository.custom.IdcardRepositoryCustom;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/flint/flint/idcard/service/IdCardBoxService.java
+++ b/src/main/java/com/flint/flint/idcard/service/IdCardBoxService.java
@@ -6,6 +6,7 @@ import com.flint.flint.idcard.repository.IdCardBoxJPARepository;
 import com.flint.flint.idcard.repository.IdCardJPARepository;
 import com.flint.flint.member.domain.main.Member;
 import com.flint.flint.member.service.MemberService;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -14,10 +15,11 @@ import org.springframework.stereotype.Service;
 public class IdCardBoxService {
 
     private final IdCardBoxJPARepository idCardBoxJPARepository;
-    private final IdCardJPARepository idCardJPARepository;
     private final MemberService memberService;
     private final IdCardService idCardService;
-    public void saveIdCardBox(Long idCardId, Long memberId) {
+
+    @Transactional
+    public void createIdCardBox(Long idCardId, Long memberId) {
         IdCard idCard = idCardService.getIdCard(idCardId);
         Member member = memberService.getMember(memberId);
 

--- a/src/main/java/com/flint/flint/idcard/service/IdCardBoxService.java
+++ b/src/main/java/com/flint/flint/idcard/service/IdCardBoxService.java
@@ -23,7 +23,7 @@ public class IdCardBoxService {
         Member member = memberService.getMember(memberId);
 
         IdCardBox idCardBox = IdCardBox.builder()
-                .idcard(idCard)
+                .idCard(idCard)
                 .member(member)
                 .build();
 

--- a/src/main/java/com/flint/flint/idcard/service/IdCardBoxService.java
+++ b/src/main/java/com/flint/flint/idcard/service/IdCardBoxService.java
@@ -1,0 +1,31 @@
+package com.flint.flint.idcard.service;
+
+import com.flint.flint.idcard.domain.IdCard;
+import com.flint.flint.idcard.domain.IdCardBox;
+import com.flint.flint.idcard.repository.IdCardBoxJPARepository;
+import com.flint.flint.idcard.repository.IdCardJPARepository;
+import com.flint.flint.member.domain.main.Member;
+import com.flint.flint.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class IdCardBoxService {
+
+    private final IdCardBoxJPARepository idCardBoxJPARepository;
+    private final IdCardJPARepository idCardJPARepository;
+    private final MemberService memberService;
+    private final IdCardService idCardService;
+    public void saveIdCardBox(Long idCardId, Long memberId) {
+        IdCard idCard = idCardService.getIdCard(idCardId);
+        Member member = memberService.getMember(memberId);
+
+        IdCardBox idCardBox = IdCardBox.builder()
+                .idcard(idCard)
+                .member(member)
+                .build();
+
+        idCardBoxJPARepository.save(idCardBox);
+    }
+}

--- a/src/main/java/com/flint/flint/idcard/service/IdCardBoxService.java
+++ b/src/main/java/com/flint/flint/idcard/service/IdCardBoxService.java
@@ -3,7 +3,6 @@ package com.flint.flint.idcard.service;
 import com.flint.flint.idcard.domain.IdCard;
 import com.flint.flint.idcard.domain.IdCardBox;
 import com.flint.flint.idcard.repository.IdCardBoxJPARepository;
-import com.flint.flint.idcard.repository.IdCardJPARepository;
 import com.flint.flint.member.domain.main.Member;
 import com.flint.flint.member.service.MemberService;
 import jakarta.transaction.Transactional;
@@ -29,5 +28,14 @@ public class IdCardBoxService {
                 .build();
 
         idCardBoxJPARepository.save(idCardBox);
+    }
+
+    @Transactional
+    public void removeIdCardBox(Long idCardId, Long memberId) {
+        IdCard idCard = idCardService.getIdCard(idCardId);
+        Member member = memberService.getMember(memberId);
+
+
+        idCardBoxJPARepository.deleteByMemberAndIdCard(member, idCard);
     }
 }

--- a/src/main/java/com/flint/flint/idcard/service/IdCardBoxService.java
+++ b/src/main/java/com/flint/flint/idcard/service/IdCardBoxService.java
@@ -35,7 +35,6 @@ public class IdCardBoxService {
         IdCard idCard = idCardService.getIdCard(idCardId);
         Member member = memberService.getMember(memberId);
 
-
         idCardBoxJPARepository.deleteByMemberAndIdCard(member, idCard);
     }
 }

--- a/src/main/java/com/flint/flint/idcard/service/IdCardFolderService.java
+++ b/src/main/java/com/flint/flint/idcard/service/IdCardFolderService.java
@@ -1,0 +1,32 @@
+package com.flint.flint.idcard.service;
+
+import com.flint.flint.idcard.domain.IdCardFolder;
+import com.flint.flint.idcard.dto.response.IdCardFolderUpdateResponse;
+import com.flint.flint.idcard.repository.IdCardInFolderJPARepository;
+import com.flint.flint.member.service.MemberService;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class IdCardFolderService {
+
+    private final IdCardInFolderJPARepository FolderJPARepository;
+    private final MemberService memberService;
+    private final IdCardService idCardService;
+
+    @Transactional
+    public IdCardFolderUpdateResponse.CreateIdCardFolderResponse createIdCardFolder(String title, Long memberId) {
+
+        IdCardFolder idcardFolder = IdCardFolder.builder()
+                .title(title)
+                .idcard(null)     //폴더 종류만 조회할 때 idcard가 null 조회
+                .member(memberService.getMember(memberId))
+                .build();
+
+        IdCardFolder saveIdCardFolder = FolderJPARepository.save(idcardFolder);
+
+        return new IdCardFolderUpdateResponse.CreateIdCardFolderResponse(saveIdCardFolder.getId());
+    }
+}

--- a/src/main/java/com/flint/flint/idcard/service/IdCardFolderService.java
+++ b/src/main/java/com/flint/flint/idcard/service/IdCardFolderService.java
@@ -2,7 +2,7 @@ package com.flint.flint.idcard.service;
 
 import com.flint.flint.idcard.domain.IdCardFolder;
 import com.flint.flint.idcard.dto.response.IdCardFolderUpdateResponse;
-import com.flint.flint.idcard.repository.IdCardInFolderJPARepository;
+import com.flint.flint.idcard.repository.IdCardFolderJPARepository;
 import com.flint.flint.member.service.MemberService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -12,20 +12,22 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class IdCardFolderService {
 
-    private final IdCardInFolderJPARepository FolderJPARepository;
+
+    private final IdCardFolderJPARepository folderJPARepository;
     private final MemberService memberService;
     private final IdCardService idCardService;
+
 
     @Transactional
     public IdCardFolderUpdateResponse.CreateIdCardFolderResponse createIdCardFolder(String title, Long memberId) {
 
-        IdCardFolder idcardFolder = IdCardFolder.builder()
+        IdCardFolder idCardFolder = IdCardFolder.builder()
                 .title(title)
                 .idCard(null)     //폴더 종류만 조회할 때 idcard가 null 조회
                 .member(memberService.getMember(memberId))
                 .build();
 
-        IdCardFolder saveIdCardFolder = FolderJPARepository.save(idcardFolder);
+        IdCardFolder saveIdCardFolder = folderJPARepository.save(idCardFolder);
 
         return new IdCardFolderUpdateResponse.CreateIdCardFolderResponse(saveIdCardFolder.getId());
     }

--- a/src/main/java/com/flint/flint/idcard/service/IdCardFolderService.java
+++ b/src/main/java/com/flint/flint/idcard/service/IdCardFolderService.java
@@ -21,7 +21,7 @@ public class IdCardFolderService {
 
         IdCardFolder idcardFolder = IdCardFolder.builder()
                 .title(title)
-                .idcard(null)     //폴더 종류만 조회할 때 idcard가 null 조회
+                .idCard(null)     //폴더 종류만 조회할 때 idcard가 null 조회
                 .member(memberService.getMember(memberId))
                 .build();
 

--- a/src/main/java/com/flint/flint/idcard/service/IdCardService.java
+++ b/src/main/java/com/flint/flint/idcard/service/IdCardService.java
@@ -50,17 +50,14 @@ public class IdCardService {
         List<InterestType> cardBackInterestTypeList = request.getCardBackInterestTypeList();
         String cardBackIntroduction = request.getCardBackIntroduction();
 
-        IdCard idCard = getIdCardById(IdCardId);
+        IdCard idCard = getIdCard(IdCardId);
         idCard.updateBack(cardBackIntroduction, cardBackMBTI, cardBackSNSId, cardBackInterestTypeList);
     }
 
-    private IdCard getIdCardById(Long idCardId) {
+    private IdCard getIdCard(Long idCardId) {
         return idCardJPARepository.findById(idCardId).orElseThrow(() -> new FlintCustomException(HttpStatus.NOT_FOUND, ResultCode.IDCARD_NOT_FOUND));
     }
 
-    /**
-     * 자신 명함 조회
-     */
     @Transactional
     public IdCardGetResponse.MyIdCard getMyIdCardByMemberId(Long memberId) {
         Member member = memberService.getMember(memberId);

--- a/src/main/java/com/flint/flint/idcard/service/IdCardService.java
+++ b/src/main/java/com/flint/flint/idcard/service/IdCardService.java
@@ -54,7 +54,7 @@ public class IdCardService {
         idCard.updateBack(cardBackIntroduction, cardBackMBTI, cardBackSNSId, cardBackInterestTypeList);
     }
 
-    private IdCard getIdCard(Long idCardId) {
+    public IdCard getIdCard(Long idCardId) {
         return idCardJPARepository.findById(idCardId).orElseThrow(() -> new FlintCustomException(HttpStatus.NOT_FOUND, ResultCode.IDCARD_NOT_FOUND));
     }
 

--- a/src/test/java/com/flint/flint/idcard/service/IdCardBoxServiceTest.java
+++ b/src/test/java/com/flint/flint/idcard/service/IdCardBoxServiceTest.java
@@ -1,0 +1,74 @@
+package com.flint.flint.idcard.service;
+
+import com.flint.flint.idcard.domain.IdCard;
+import com.flint.flint.idcard.domain.IdCardBox;
+import com.flint.flint.idcard.repository.IdCardBoxJPARepository;
+import com.flint.flint.member.domain.main.Member;
+import com.flint.flint.member.service.MemberService;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class IdCardBoxServiceTest {
+
+    @InjectMocks
+    IdCardBoxService idCardBoxService;
+
+    @Mock
+    IdCardBoxJPARepository idCardBoxJPARepository;
+
+    @Mock
+    IdCardService idCardService;
+
+    @Mock
+    MemberService memberService;
+
+    /**
+     * BDD Mockito
+     */
+    @Test
+    @DisplayName("명함박스 생성 서비스 테스트")
+    void createIdCardBoxTest() {
+        //given
+        Long idCardId = 1L;
+        Long memberId = 1L;
+        IdCard idCard = new IdCard();
+        Member member = new Member();
+
+        given(idCardService.getIdCard(idCardId)).willReturn(idCard); //Mockito.when()에 해당
+        given(memberService.getMember(memberId)).willReturn(member);
+
+        // when
+        idCardBoxService.createIdCardBox(idCardId, memberId);
+
+        // then
+        then(idCardBoxJPARepository).should().save(any(IdCardBox.class));
+    }
+
+    @Test
+    @DisplayName("명함박스 생성 서비스 테스트")
+    void removeIdCardBox() {
+        //given
+        Long idCardId = 1L;
+        Long memberId = 1L;
+        IdCard idCard = new IdCard();
+        Member member = new Member();
+
+        given(idCardService.getIdCard(idCardId)).willReturn(idCard); //Mockito.when()에 해당
+        given(memberService.getMember(memberId)).willReturn(member);
+
+        //when
+        idCardBoxService.removeIdCardBox(idCardId, memberId);
+
+
+        //then
+        then(idCardBoxJPARepository).should().deleteByMemberAndIdCard(member,idCard);
+    }
+}

--- a/src/test/java/com/flint/flint/idcard/service/IdCardFolderServiceTest.java
+++ b/src/test/java/com/flint/flint/idcard/service/IdCardFolderServiceTest.java
@@ -1,0 +1,48 @@
+package com.flint.flint.idcard.service;
+
+import com.flint.flint.idcard.domain.IdCardFolder;
+import com.flint.flint.idcard.dto.response.IdCardFolderUpdateResponse;
+import com.flint.flint.idcard.repository.IdCardFolderJPARepository;
+import com.flint.flint.member.domain.main.Member;
+import com.flint.flint.member.service.MemberService;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class IdCardFolderServiceTest {
+    @InjectMocks
+    IdCardFolderService idCardFolderService;
+
+    @Mock
+    IdCardFolderJPARepository folderJPARepository;
+    @Mock
+    MemberService memberService;
+    @Mock
+    IdCardFolderUpdateResponse.CreateIdCardFolderResponse createIdCardFolderResponse;
+
+    @Test
+    @DisplayName("명함폴더 생성 서비스 테스트")
+    void createIdCardFolderTest(){
+        //given
+        String title = "Test Folder";
+        Long memberId = 1L;
+        Member member = new Member();
+
+        given(memberService.getMember(memberId)).willReturn(member);
+        given(folderJPARepository.save(any(IdCardFolder.class))).willReturn(mock(IdCardFolder.class));
+
+        // when
+        idCardFolderService.createIdCardFolder(title, memberId);
+
+        // then
+        then(folderJPARepository).should().save(any(IdCardFolder.class));
+    }
+}


### PR DESCRIPTION
## 관련 이슈
close #53 
## 변경사항
- 타인 명함 명함박스에 추가, 삭제 API         IdCardBoxUpdateController
- 명함박스에 폴더 생성 API                          IdCardFolderUpdateController
- Security Config 수정

## 개발하면서 발생한 문제점과 해결방안 또는 새롭게 알게된 점
- mock사용 
     - 제가 mock 쓰면 고민한 기록이 담긴 노션입니다 (기록하는 습관을 들이고 있는 과정이라 글이라고 하기도 민망합니당)
     - https://invented-streetcar-5cd.notion.site/Mock-7cfe43e692db47da8eb072c877217292?pvs=4 

- IdCardFolder 속성 고민
![image](https://github.com/Flint-org/Flint-API-Server/assets/92251131/e8bddab4-1d2a-47a9-9c67-f69db3041393)

## 당부하고 싶은 말 또는 논의해봐야할 점

-  https://cheese10yun.github.io/spring-guide-service/#-2
    요새 좋은 코드가 무엇인지 고민을 많이 하는 것 같아용 괜찮은 글이라 공유드리고 싶어 남깁니다 이미 알고 계신다면..(뻘쭘)
- member 주입하여 생성하는 객체들 만들 때
isTokenValid로 token 안에 객체를 한 번 검증한다. AuthorityMemberDTO에 있는 memberId는 검증을 한 거죠.
앞으로 member를 주입시켜 생성해야 하는 객체를 만들 때, memberservice.getMember로 데이터베이스 한 번 더 조회하지 말고 getReference()로 member id만 가져오는 건 어떠한가요?

- mock을 사용했지만 3개 테스트 하는데 6초가 걸렸습니다. 굉장히 느린 거라 생각합니다. 느린 이유에 대해 생각중입니당
## 스크린샷
![image](https://github.com/Flint-org/Flint-API-Server/assets/92251131/9997c073-7347-47c8-9ee9-3fceb75947e5)

## 기타 및 추후 계획
시큐리티 AccessDeniedHandle구현
