### PR TITLE
feat: 게시글 생성 api 구현

### DIFF
--- a/src/main/java/com/flint/flint/common/spec/ResultCode.java
+++ b/src/main/java/com/flint/flint/common/spec/ResultCode.java
@@ -28,6 +28,7 @@ public enum ResultCode {
 
     // F4xx: 커뮤니티, 게시글 예외
     MAJOR_BOARD_NOT_FOUND("F400", "존재하지 않는 전공 게시판입니다."),
+    BOARD_NOT_FOUND("F401", "존재하지 않는 게시판입니다."),
 
     // F5xx: 모임 예외
     CLUB_NOT_FOUND_ERROR("F500", "모임을 찾을 수 없습니다."),

--- a/src/main/java/com/flint/flint/community/controller/PostApiController.java
+++ b/src/main/java/com/flint/flint/community/controller/PostApiController.java
@@ -1,0 +1,37 @@
+package com.flint.flint.community.controller;
+
+import com.flint.flint.common.ResponseForm;
+import com.flint.flint.community.dto.request.PostRequest;
+import com.flint.flint.community.dto.response.PostPreSignedUrlResponse;
+import com.flint.flint.community.service.PostService;
+import com.flint.flint.security.auth.dto.AuthorityMemberDTO;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * @author 신승건
+ * @since 2023-09-13
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/posts")
+public class PostApiController {
+    private final PostService postService;
+
+    @PreAuthorize("hasRole('ROLE_AUTHUSER')")
+    @PostMapping("")
+    public ResponseForm<List<PostPreSignedUrlResponse>> createPost(
+            @AuthenticationPrincipal AuthorityMemberDTO memberDTO,
+            @Valid @RequestBody PostRequest postRequest
+    ) {
+        return new ResponseForm<>(postService.createPost(memberDTO.getEmail(), postRequest));
+    }
+}

--- a/src/main/java/com/flint/flint/community/domain/post/Post.java
+++ b/src/main/java/com/flint/flint/community/domain/post/Post.java
@@ -8,6 +8,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * 게시글 엔티티
  *
@@ -38,11 +41,19 @@ public class Post extends BaseTimeEntity {
     @Column(length = 1000, nullable = false)
     private String contents;
 
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private final List<PostImage> postImages = new ArrayList<>();
+
     @Builder
     public Post(Member member, Board board, String title, String contents) {
         this.member = member;
         this.board = board;
         this.title = title;
         this.contents = contents;
+    }
+
+    public void addImageUrl(PostImage postImage){
+        this.postImages.add(postImage);
+        postImage.changePost(this);
     }
 }

--- a/src/main/java/com/flint/flint/community/domain/post/PostImage.java
+++ b/src/main/java/com/flint/flint/community/domain/post/PostImage.java
@@ -34,4 +34,8 @@ public class PostImage extends BaseTimeEntity {
         this.post = post;
         this.imgUrl = imgUrl;
     }
+
+    public void changePost(Post post){
+        this.post = post;
+    }
 }

--- a/src/main/java/com/flint/flint/community/dto/request/PostRequest.java
+++ b/src/main/java/com/flint/flint/community/dto/request/PostRequest.java
@@ -1,0 +1,23 @@
+package com.flint.flint.community.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostRequest {
+    private Long boardId;
+    @NotBlank
+    private String title;
+    @NotBlank
+    private String contents;
+    private List<String> fileNames = new ArrayList<>();
+}

--- a/src/main/java/com/flint/flint/community/dto/response/PostPreSignedUrlResponse.java
+++ b/src/main/java/com/flint/flint/community/dto/response/PostPreSignedUrlResponse.java
@@ -1,0 +1,15 @@
+package com.flint.flint.community.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostPreSignedUrlResponse {
+    private String fileName;
+    private String preSignedUrl;
+}

--- a/src/main/java/com/flint/flint/community/repository/PostRepository.java
+++ b/src/main/java/com/flint/flint/community/repository/PostRepository.java
@@ -1,0 +1,7 @@
+package com.flint.flint.community.repository;
+
+import com.flint.flint.community.domain.post.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+}

--- a/src/main/java/com/flint/flint/community/service/BoardService.java
+++ b/src/main/java/com/flint/flint/community/service/BoardService.java
@@ -112,6 +112,10 @@ public class BoardService {
                                 .build())
                         .toList())
                 .build();
+    }
 
+    public Board getBoard(Long boardId) {
+        return boardRepository.findById(boardId)
+                .orElseThrow(() -> new FlintCustomException(HttpStatus.NOT_FOUND, BOARD_NOT_FOUND));
     }
 }

--- a/src/main/java/com/flint/flint/community/service/PostService.java
+++ b/src/main/java/com/flint/flint/community/service/PostService.java
@@ -1,0 +1,79 @@
+package com.flint.flint.community.service;
+
+import com.flint.flint.common.exception.FlintCustomException;
+import com.flint.flint.common.spec.ResultCode;
+import com.flint.flint.community.domain.board.Board;
+import com.flint.flint.community.domain.post.Post;
+import com.flint.flint.community.domain.post.PostImage;
+import com.flint.flint.community.dto.request.PostRequest;
+import com.flint.flint.community.dto.response.PostPreSignedUrlResponse;
+import com.flint.flint.community.repository.PostRepository;
+import com.flint.flint.media.dto.response.PreSignedUrlResponse;
+import com.flint.flint.media.service.MediaService;
+import com.flint.flint.member.domain.main.Member;
+import com.flint.flint.member.repository.MemberRepository;
+import com.flint.flint.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author 신승건
+ * @since 2023-09-13
+ */
+@Service
+@RequiredArgsConstructor
+public class PostService {
+    private final PostRepository postRepository;
+    private final MemberService memberService;
+    private final BoardService boardService;
+    private final MediaService mediaService;
+    private final MemberRepository memberRepository;
+    private static final String POST_IMAGE_FOLDER_NAME = "static";
+
+    @Transactional
+    public List<PostPreSignedUrlResponse> createPost(String email, PostRequest postRequest) {
+        Member member = memberRepository.findByEmail(email).
+                orElseThrow(() -> new FlintCustomException(HttpStatus.NOT_FOUND, ResultCode.USER_NOT_FOUND));
+
+        Board board = boardService.getBoard(postRequest.getBoardId());
+
+        Post post = Post.builder()
+                .board(board)
+                .title(postRequest.getTitle())
+                .contents(postRequest.getContents())
+                .member(member)
+                .build();
+
+        List<PostPreSignedUrlResponse> preSignedUrls = new ArrayList<>();
+
+        // 저장할 파일이 있다면
+        for (String fileName : postRequest.getFileNames()) {
+            String path = "/" + POST_IMAGE_FOLDER_NAME + "/" + fileName;
+
+            // pre-signed url 요청
+            PreSignedUrlResponse preSignedURL = mediaService.getPreSignedURL(POST_IMAGE_FOLDER_NAME, fileName);
+
+            // 이미지 엔티티 생성
+            PostImage postImage = PostImage.builder()
+                    .imgUrl(path)
+                    .build();
+
+            // 게시글의 이미지 리스트에 추가
+            post.addImageUrl(postImage);
+
+            // 응답 데이터 추가
+            preSignedUrls.add(PostPreSignedUrlResponse.builder()
+                    .fileName(fileName)
+                    .preSignedUrl(preSignedURL.getPreSignedUrl())
+                    .build()
+            );
+        }
+        postRepository.save(post);
+        return preSignedUrls;
+    }
+}

--- a/src/main/java/com/flint/flint/config/SecurityConfig.java
+++ b/src/main/java/com/flint/flint/config/SecurityConfig.java
@@ -11,7 +11,6 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 
 @Configuration

--- a/src/main/java/com/flint/flint/media/service/MediaService.java
+++ b/src/main/java/com/flint/flint/media/service/MediaService.java
@@ -125,6 +125,9 @@ public class MediaService {
      * @return Pre-Signed URL
      */
     public PreSignedUrlResponse getPreSignedURL(String folderName, String fileName) {
+        if (!isValidImageExtension(fileName))
+            throw new FlintCustomException(HttpStatus.BAD_REQUEST, INVALID_IMAGE_EXTENSION_TYPE);
+
         String path = folderName + "/" + fileName;
 
         URL url = s3Client.generatePresignedUrl(getGeneratePreSignedUrlRequest(path));

--- a/src/test/java/com/flint/flint/community/controller/PostApiControllerTest.java
+++ b/src/test/java/com/flint/flint/community/controller/PostApiControllerTest.java
@@ -1,0 +1,120 @@
+package com.flint.flint.community.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.flint.flint.community.domain.board.Board;
+import com.flint.flint.community.dto.request.PostRequest;
+import com.flint.flint.community.repository.BoardRepository;
+import com.flint.flint.community.spec.BoardType;
+import com.flint.flint.custom_member.WithMockCustomMember;
+import com.flint.flint.member.domain.main.Member;
+import com.flint.flint.member.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@Transactional
+@AutoConfigureMockMvc
+class PostApiControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private BoardRepository boardRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private static final String BASE_URL = "/api/v1/posts";
+
+    @Test
+    @DisplayName("학교 인증을 받지 않은 회원은 게시글 생성 시 예외가 발생한다.")
+    @WithMockCustomMember(role = "ROLE_ANAUTHUSER")
+    void createPostWithoutCredential() throws Exception {
+        Board board = Board.builder()
+                .boardType(BoardType.GENERAL)
+                .generalBoardName("자유게시판")
+                .build();
+
+        Board savedBoard = boardRepository.save(board);
+        List<String> fileNames = new ArrayList<>();
+        fileNames.add("abcd.jpg");
+        fileNames.add("efgh.jpg");
+        fileNames.add("ijkl.jpg");
+
+        PostRequest postRequest = PostRequest.builder()
+                .title("제목입니다")
+                .contents("게시글을 생성하는 테스트 코드입니다")
+                .fileNames(fileNames)
+                .boardId(savedBoard.getId())
+                .build();
+
+        String json = convertDtoToJson(postRequest);
+
+        this.mockMvc.perform(post(BASE_URL)
+                        .content(json)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isInternalServerError());
+    }
+
+    @Test
+    @DisplayName("학교 인증을 받은 회원은 게시글 생성에 성공한다.")
+    @WithMockCustomMember
+    void createPost() throws Exception {
+        Board board = Board.builder()
+                .boardType(BoardType.GENERAL)
+                .generalBoardName("자유게시판")
+                .build();
+
+        Board savedBoard = boardRepository.save(board);
+
+        Member member = Member.builder()
+                .name("테스터")
+                .email("test@test.com")
+                .providerName("kakao")
+                .providerId("test")
+                .build();
+
+        memberRepository.save(member);
+
+        List<String> fileNames = new ArrayList<>();
+        fileNames.add("abcd.jpg");
+        fileNames.add("efgh.jpg");
+        fileNames.add("ijkl.jpg");
+
+        PostRequest postRequest = PostRequest.builder()
+                .title("제목입니다")
+                .contents("게시글을 생성하는 테스트 코드입니다")
+                .fileNames(fileNames)
+                .boardId(savedBoard.getId())
+                .build();
+
+        String json = convertDtoToJson(postRequest);
+
+        this.mockMvc.perform(post(BASE_URL)
+                        .content(json)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    private String convertDtoToJson(Object obj) throws JsonProcessingException {
+        objectMapper.configure(SerializationFeature.WRAP_ROOT_VALUE, false);
+        ObjectWriter objectWriter = objectMapper.writer().withDefaultPrettyPrinter();
+        return objectWriter.writeValueAsString(obj);
+    }
+}

--- a/src/test/java/com/flint/flint/community/service/PostServiceTest.java
+++ b/src/test/java/com/flint/flint/community/service/PostServiceTest.java
@@ -1,0 +1,124 @@
+package com.flint.flint.community.service;
+
+import com.flint.flint.common.exception.FlintCustomException;
+import com.flint.flint.common.spec.ResultCode;
+import com.flint.flint.community.domain.board.Board;
+import com.flint.flint.community.domain.post.Post;
+import com.flint.flint.community.dto.request.PostRequest;
+import com.flint.flint.community.dto.response.PostPreSignedUrlResponse;
+import com.flint.flint.community.repository.BoardRepository;
+import com.flint.flint.community.repository.PostRepository;
+import com.flint.flint.community.spec.BoardType;
+import com.flint.flint.member.domain.main.Member;
+import com.flint.flint.member.repository.MemberRepository;
+import com.flint.flint.member.spec.Authority;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class PostServiceTest {
+    @Autowired
+    private PostService postService;
+    @Autowired
+    private PostRepository postRepository;
+    @Autowired
+    private BoardRepository boardRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("Pre-Signed URL 방식의 게시글 생성에 성공한다.")
+    void createPost() {
+        // given
+        Member member = Member.builder()
+                .name("홍길동")
+                .authority(Authority.AUTHUSER)
+                .email("test@test.com")
+                .providerId("test")
+                .providerName("kakao")
+                .build();
+
+        Member savedMember = memberRepository.save(member);
+
+        Board board = Board.builder()
+                .boardType(BoardType.GENERAL)
+                .generalBoardName("자유게시판")
+                .build();
+
+        Board savedBoard = boardRepository.save(board);
+
+        List<String> fileNames = new ArrayList<>();
+        fileNames.add("abcd.jpg");
+        fileNames.add("efgh.jpg");
+        fileNames.add("ijkl.jpg");
+
+        PostRequest postRequest = PostRequest.builder()
+                .title("제목입니다")
+                .contents("게시글을 생성하는 테스트 코드입니다")
+                .fileNames(fileNames)
+                .boardId(savedBoard.getId())
+                .build();
+
+        // when
+        List<PostPreSignedUrlResponse> responses = postService.createPost(savedMember.getEmail(), postRequest);
+
+        List<Post> postList = postRepository.findAll();
+
+        // then
+        assertEquals(3, responses.size());
+
+        assertEquals("/static/abcd.jpg", postList.get(0).getPostImages().get(0).getImgUrl());
+        assertEquals("제목입니다", postList.get(0).getTitle());
+        assertEquals(BoardType.GENERAL, postList.get(0).getBoard().getBoardType());
+        assertEquals("자유게시판", postList.get(0).getBoard().getGeneralBoardName());
+        assertEquals("홍길동", postList.get(0).getMember().getName());
+    }
+
+    @Test
+    @DisplayName("게시글을 저장할 때 파일 형식이 이미지가 아니라면 예외가 발생한다.")
+    void createPostWithImageType() {
+        // given
+        Member member = Member.builder()
+                .name("홍길동")
+                .authority(Authority.AUTHUSER)
+                .email("test@test.com")
+                .providerId("test")
+                .providerName("kakao")
+                .build();
+
+        Member savedMember = memberRepository.save(member);
+
+        Board board = Board.builder()
+                .boardType(BoardType.GENERAL)
+                .generalBoardName("자유게시판")
+                .build();
+
+        Board savedBoard = boardRepository.save(board);
+
+        List<String> fileNames = new ArrayList<>();
+        fileNames.add("abcd.jpg");
+        fileNames.add("efgh.xxxx");
+
+        PostRequest postRequest = PostRequest.builder()
+                .title("제목입니다")
+                .contents("게시글을 생성하는 테스트 코드입니다")
+                .fileNames(fileNames)
+                .boardId(savedBoard.getId())
+                .build();
+
+        // then, when
+        assertThatThrownBy(() -> postService.createPost(savedMember.getEmail(), postRequest))
+                .isInstanceOf(FlintCustomException.class)
+                .hasMessage(ResultCode.INVALID_IMAGE_EXTENSION_TYPE.getMessage());
+    }
+}

--- a/src/test/java/com/flint/flint/custom_member/WithMockCustomMember.java
+++ b/src/test/java/com/flint/flint/custom_member/WithMockCustomMember.java
@@ -1,0 +1,12 @@
+package com.flint.flint.custom_member;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockCustomMemberSecurityContextFactory.class)
+public @interface WithMockCustomMember {
+    String role() default "ROLE_AUTHUSER";
+}

--- a/src/test/java/com/flint/flint/custom_member/WithMockCustomMemberSecurityContextFactory.java
+++ b/src/test/java/com/flint/flint/custom_member/WithMockCustomMemberSecurityContextFactory.java
@@ -1,0 +1,34 @@
+package com.flint.flint.custom_member;
+
+import com.flint.flint.member.domain.main.Member;
+import com.flint.flint.member.repository.MemberRepository;
+import com.flint.flint.member.spec.Authority;
+import com.flint.flint.security.auth.dto.AuthorityMemberDTO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+import java.util.Collection;
+import java.util.Set;
+
+public class WithMockCustomMemberSecurityContextFactory implements WithSecurityContextFactory<WithMockCustomMember> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithMockCustomMember annotation) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        Collection<? extends GrantedAuthority> authorities = Set.of(new SimpleGrantedAuthority(annotation.role()));
+
+        AuthorityMemberDTO authMember = AuthorityMemberDTO.builder()
+                .id(1L)
+                .email("test@test.com")
+                .providerId("kakao")
+                .providerId("test")
+                .build();
+        context.setAuthentication(new UsernamePasswordAuthenticationToken(authMember, "", authorities));
+        return context;
+    }
+}


### PR DESCRIPTION
## 관련 이슈
close #48 
## 변경사항
### 게시글 생성 API 구현
- 이미지 처리는 Pre-Signed URL 방식 도입
  - 응답으로 각 이미지마다의 Pre-Signed URL 제공
  - Pre-Signed URL 요청 시, 이미지 포맷 검증 추가
- Post와 PostImage 엔티티간의 양방향 관계 설정

### Mocking 테스트 설정
- API 테스트를 하기 위해서 유저 인증 및 권한에 대한 처리를 해주어야하는데, 매 API 테스트를 할 때마다 코드를 작성해줘야하고, 권한 처리도 각기 달라질 수 있었기 때문에 자동화하고자 했다.
- `WithSecurityContextFactory<A>` 인터페이스를 사용하여 SecurityContextHolder에 principal 객체를 미리 주입해주도록 하였고, 이는 WithMockCustomMember 커스텀 어노테이션을 통해 각 테스트 메소드에다가 붙여주면 자동으로 적용이 된다.
- 어노테이션을 사용할 때 권한(역할)을 동적으로 설정해줄 수 있도록 하였다. (`role()`) (default 값은 인증된 유저)
## 개발하면서 발생한 문제점과 해결방안 또는 새롭게 알게된 점
- 유저 인증을 어노테이션으로 자동으로 처리할 때 큰 문제가 발생했다. 
  - principal 객체를 만들 때, 유저의 PK 값을 넣어줬어야 했는데 이는 통합 테스트를 할 때, 같은 환경에서 여러 멤버 객체가 생성 및 삭제를 거치다보니 auto increment 시퀀스 값이 유지되어서 설정한 값과 통일할 수가 없었다.
  - 또한 JPA에서 PK 값을 임의로 설정하고 저장해도 지정한 임의의 값은 무시되고, 자동으로 시퀀스의 값으로 저장되기 때문에 손 쓸 방법이 없었다. 
  - 그래서 생각난 방법은 서비스 로직에서 멤버 처리를 할 때, ID 값이 아니라 이메일 값으로 하는 것이다. 
    - 만약에 이메일 값으로 처리해야한다면 이메일 값을 Unique 제약조건을 걸고, 회원가입할 때 중복 체크를 해줘야 안정적으로 사용할 수 있을 것이다. 
  - 이메일로 조회를 하게 된다면, 주입한 principal 객체의 이메일과 테스트에서 생성한 멤버 객체의 이메일을 동일하게 저장해주면 정상적으로 테스트가 성공적으로 이루어진다 
## 당부하고 싶은 말 또는 논의해봐야할 점
### 권한 에러처리
- 권한이 없는 경우에 대한 테스트를 하니 예외처리가 없어 바로 500 에러가 발생하였다. (이 부분은 순원님께서 처리해주시기로 하심)
  - 엔트리 포인트에서 커스텀 에러 처리를 해주도록!
### API 접근 권한 설정
- 현재 SecurityConfig에서 request matchers로 한번에 특정 path는 허용, 특정 path는 권한이 있는 경우 아니면 같은 path이지만 특정 Http Method에 대해서는 권한을 다르게해주는 것을 보았는데
- API마다 다르겠지만 요구사항에 따라 같은 Http Method여도 권한 처리를 다르게 해줘야하는 경우가 있을 수 있기 때문에(커뮤니티 경우, 게시글 목록은 누구나 볼 수 있지만 상세 게시글은 권한이 있어야만 볼 수 있다) 따로 `@PreAuthorize` 어노테이션을 통해 각 컨트롤러 메소드마다 권한 설정을 부여하였습니다

### 유저 인증 자동화 어노테이션 관련
- 위 개발하면서 발생한 문제점과 해결방안에서 이야기 했던 것 처럼 API mocking 테스트 시, 유저 인증 처리를 할 때, 중복되는 코드를 최소화하기 위해 어노테이션을 사용하는데
- 비즈니스 로직에서 principal 객체의 id 값을 사용하여 멤버를 조회해오는 것이 아니라 이메일로 조회하도록 해서 PK dependency로부터 벗어나게끔 하는게 좋을 것 같다는 생각입니다. 
  - 물론 이메일로 한다면 이메일 중복 방지를 필수로 해줘야합니다
  - 다른 코드도 참고하였는데, ID를 직접 사용하지 않는 것으로 보여졌고 나쁘지않은 방법이라고 생각이 듭니다.
 
### 어노테이션 사용 주의
- 유저 인증 처리를 위해 어노테이션을 사용할 때, 인증이 필요한 경우에는 Member 객체를 꼭 만들고 저장해줘야한다.
- 인증이 안된 유저로 사용하고 싶다면  `@WithMockCustomMember(role = "ROLE_ANAUTHUSER")` 처럼 사용해야합니다.

## 스크린샷
![image](https://github.com/Flint-org/Flint-API-Server/assets/54919474/d5465e7d-8433-49fb-9f35-95cfa4709a83)
![image](https://github.com/Flint-org/Flint-API-Server/assets/54919474/401ab583-edd5-4839-bd41-c7ad5d8b0360)

## 기타 및 추후 계획
- Pre-Signed URL 문서를 아직 작성 못했었는데 구현하면서 동시에 작성 완료했습니다