### PR TITLE
feat: 게시판 즐겨찾기 등록 API 구현

### DIFF
--- a/src/main/java/com/flint/flint/club/controller/main/ClubController.java
+++ b/src/main/java/com/flint/flint/club/controller/main/ClubController.java
@@ -3,14 +3,13 @@ package com.flint.flint.club.controller.main;
 import com.flint.flint.club.domain.main.Club;
 import com.flint.flint.club.domain.spec.ClubCategoryType;
 import com.flint.flint.club.request.ClubCreateRequest;
-import com.flint.flint.club.request.PageRequest;
 import com.flint.flint.club.response.ClubDetailGetResponse;
-import com.flint.flint.club.response.ClubsGetResponse;
 import com.flint.flint.club.service.comment.ClubCommentServiceImpl;
 import com.flint.flint.club.service.main.ClubServiceImpl;
 import com.flint.flint.common.ResponseForm;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 /**
@@ -25,6 +24,7 @@ public class ClubController {
     private final ClubServiceImpl clubService;
     private final ClubCommentServiceImpl clubCommentService;
 
+    @PreAuthorize("hasRole('ROLE_AUTHUSER')")
     @PostMapping(path = "")
     public void createClub(@RequestBody ClubCreateRequest clubCreateRequest) {
         clubService.createClub(clubCreateRequest);

--- a/src/main/java/com/flint/flint/common/spec/ResultCode.java
+++ b/src/main/java/com/flint/flint/common/spec/ResultCode.java
@@ -32,6 +32,7 @@ public enum ResultCode {
     MAJOR_BOARD_NOT_FOUND("F400", "존재하지 않는 전공 게시판입니다."),
     BOARD_NOT_FOUND("F401", "존재하지 않는 게시판입니다."),
     EXCESS_POST_IMAGE_LIMIT("F402", "게시글의 최대 이미지 개수는 20장입니다."),
+    ALREADY_BOOKMARKED_BOARD("F403", "이미 즐겨찾기된 게시판입니다."),
 
     // F5xx: 모임 예외
     CLUB_NOT_FOUND_ERROR("F500", "모임을 찾을 수 없습니다."),

--- a/src/main/java/com/flint/flint/community/controller/BoardApiController.java
+++ b/src/main/java/com/flint/flint/community/controller/BoardApiController.java
@@ -6,7 +6,10 @@ import com.flint.flint.community.dto.response.MajorBoardResponse;
 import com.flint.flint.community.dto.response.UpperMajorInfoResponse;
 import com.flint.flint.community.dto.response.UpperMajorListResponse;
 import com.flint.flint.community.service.BoardService;
+import com.flint.flint.security.auth.dto.AuthorityMemberDTO;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -23,6 +26,23 @@ import java.util.List;
 public class BoardApiController {
 
     private final BoardService boardService;
+
+    /**
+     * 게시판 즐겨찾기 등록
+     *
+     * @param memberDTO 유저
+     * @param boardId   즐겨찾기할 게시판 ID
+     * @return x
+     */
+    @PreAuthorize("hasRole('ROLE_AUTHUSER')")
+    @PostMapping("/{boardId}/bookmark")
+    public ResponseForm<Void> bookmarkBoard(
+            @AuthenticationPrincipal AuthorityMemberDTO memberDTO,
+            @PathVariable("boardId") Long boardId
+    ) {
+        boardService.bookmarkBoard(memberDTO.getProviderId(), boardId);
+        return new ResponseForm<>();
+    }
 
     /**
      * 일반 게시판 목록 조회 API
@@ -66,5 +86,4 @@ public class BoardApiController {
     ) {
         return new ResponseForm<>(boardService.getLowerMajorListByUpperMajor(upperMajorId));
     }
-
 }

--- a/src/main/java/com/flint/flint/community/controller/PostApiController.java
+++ b/src/main/java/com/flint/flint/community/controller/PostApiController.java
@@ -32,6 +32,6 @@ public class PostApiController {
             @AuthenticationPrincipal AuthorityMemberDTO memberDTO,
             @Valid @RequestBody PostRequest postRequest
     ) {
-        return new ResponseForm<>(postService.createPost(memberDTO.getEmail(), postRequest));
+        return new ResponseForm<>(postService.createPost(memberDTO.getProviderId(), postRequest));
     }
 }

--- a/src/main/java/com/flint/flint/community/domain/board/BoardBookmark.java
+++ b/src/main/java/com/flint/flint/community/domain/board/BoardBookmark.java
@@ -1,0 +1,38 @@
+package com.flint.flint.community.domain.board;
+
+import com.flint.flint.common.BaseTimeEntity;
+import com.flint.flint.member.domain.main.Member;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 게시판 즐겨찾기 엔티티
+ * @author 신승건
+ * @since 2023-09-18
+ */
+@Entity
+@NoArgsConstructor
+@Getter
+public class BoardBookmark extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "BOARD_BOOKMARK_ID")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "BOARD_ID")
+    private Board board;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "MEMBER_ID")
+    private Member member;
+
+    @Builder
+    public BoardBookmark(Board board, Member member) {
+        this.board = board;
+        this.member = member;
+    }
+}

--- a/src/main/java/com/flint/flint/community/repository/BoardBookmarkRepository.java
+++ b/src/main/java/com/flint/flint/community/repository/BoardBookmarkRepository.java
@@ -1,0 +1,10 @@
+package com.flint.flint.community.repository;
+
+import com.flint.flint.community.domain.board.Board;
+import com.flint.flint.community.domain.board.BoardBookmark;
+import com.flint.flint.member.domain.main.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BoardBookmarkRepository extends JpaRepository<BoardBookmark, Long> {
+    boolean existsByMemberAndBoard(Member member, Board board);
+}

--- a/src/main/java/com/flint/flint/community/repository/BoardRepository.java
+++ b/src/main/java/com/flint/flint/community/repository/BoardRepository.java
@@ -5,8 +5,11 @@ import com.flint.flint.community.spec.BoardType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
 
     List<Board> findBoardsByBoardType(BoardType type);
+
+    Optional<Board> findBoardByGeneralBoardName(String name);
 }

--- a/src/main/java/com/flint/flint/community/repository/MajorBoardRepository.java
+++ b/src/main/java/com/flint/flint/community/repository/MajorBoardRepository.java
@@ -4,10 +4,13 @@ import com.flint.flint.community.domain.board.MajorBoard;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface MajorBoardRepository extends JpaRepository<MajorBoard, Long> {
 
     List<MajorBoard> findMajorBoardsByUpperMajorBoardIsNull();
 
     List<MajorBoard> findMajorBoardsByUpperMajorBoard(MajorBoard upperMajor);
+
+    Optional<MajorBoard> findMajorBoardByName(String majorName);
 }

--- a/src/main/java/com/flint/flint/community/service/PostService.java
+++ b/src/main/java/com/flint/flint/community/service/PostService.java
@@ -11,6 +11,7 @@ import com.flint.flint.media.dto.response.PreSignedUrlResponse;
 import com.flint.flint.media.service.MediaService;
 import com.flint.flint.member.domain.main.Member;
 import com.flint.flint.member.repository.MemberRepository;
+import com.flint.flint.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -34,13 +35,13 @@ public class PostService {
     private final BoardService boardService;
     private final MediaService mediaService;
     private final MemberRepository memberRepository;
+    private final MemberService memberService;
     private static final String POST_IMAGE_FOLDER_NAME = "static";
     private static final int MAX_IMAGE_LIMIT = 20;
 
     @Transactional
-    public List<PostPreSignedUrlResponse> createPost(String email, PostRequest postRequest) {
-        Member member = memberRepository.findByEmail(email).
-                orElseThrow(() -> new FlintCustomException(HttpStatus.NOT_FOUND, USER_NOT_FOUND));
+    public List<PostPreSignedUrlResponse> createPost(String providerId, PostRequest postRequest) {
+        Member member = memberService.getMemberByProviderId(providerId);
 
         // 이미지 개수 제한 검증
         if (isExceedMaxImage(postRequest.getFileNames().size()))

--- a/src/main/java/com/flint/flint/member/domain/main/Member.java
+++ b/src/main/java/com/flint/flint/member/domain/main/Member.java
@@ -49,7 +49,7 @@ public class Member extends BaseTimeEntity {
 
     //유저, 관리자
     @Enumerated(EnumType.STRING)
-    private Authority authority = Authority.ANAUTHUSER;
+    private Authority authority = Authority.UNAUTHUSER;
 
     @NotNull
     private String providerName;

--- a/src/main/java/com/flint/flint/member/service/MemberService.java
+++ b/src/main/java/com/flint/flint/member/service/MemberService.java
@@ -26,4 +26,10 @@ public class MemberService {
         return memberRepository.findById(id)
                 .orElseThrow(() -> new FlintCustomException(HttpStatus.NOT_FOUND, USER_NOT_FOUND));
     }
+
+    @Transactional(readOnly = true)
+    public Member getMemberByProviderId(String providerId) {
+        return memberRepository.findByProviderId(providerId)
+                .orElseThrow(() -> new FlintCustomException(HttpStatus.NOT_FOUND, USER_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/flint/flint/member/spec/Authority.java
+++ b/src/main/java/com/flint/flint/member/spec/Authority.java
@@ -12,7 +12,7 @@ import lombok.Getter;
 public enum Authority {
 
     AUTHUSER("ROLE_AUTHUSER"),
-    ANAUTHUSER("ROLE_UNAUTHUSER"),
+    UNAUTHUSER("ROLE_UNAUTHUSER"),
     ADMIN("ROLE_ADMIN");
 
     private final String role;

--- a/src/test/java/com/flint/flint/club/controller/ClubControllerTest.java
+++ b/src/test/java/com/flint/flint/club/controller/ClubControllerTest.java
@@ -5,6 +5,9 @@ import com.flint.flint.club.controller.main.ClubController;
 import com.flint.flint.club.domain.spec.*;
 import com.flint.flint.club.repository.main.ClubRepository;
 import com.flint.flint.club.request.ClubCreateRequest;
+import com.flint.flint.custom_member.WithMockCustomMember;
+import com.flint.flint.member.domain.main.Member;
+import com.flint.flint.member.repository.MemberRepository;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -21,6 +24,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @AutoConfigureMockMvc
 public class ClubControllerTest {
+
+    @Autowired
+    MemberRepository memberRepository;
     @Autowired
     ClubController clubController;
     @Autowired
@@ -35,7 +41,16 @@ public class ClubControllerTest {
     @Test
     @DisplayName("모임 생성 컨트롤러 테스트")
     @Transactional
-    void test1() throws Exception{
+    @WithMockCustomMember
+    void test1() throws Exception {
+        Member member = Member.builder()
+                .name("테스터")
+                .email("test@test.com")
+                .providerName("kakao")
+                .providerId("kakao test")
+                .build();
+
+        memberRepository.save(member);
 
         String requestBody = objectMapper.writeValueAsString(
                 ClubCreateRequest.builder()

--- a/src/test/java/com/flint/flint/community/controller/BoardApiControllerTest.java
+++ b/src/test/java/com/flint/flint/community/controller/BoardApiControllerTest.java
@@ -1,0 +1,57 @@
+package com.flint.flint.community.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flint.flint.community.domain.board.Board;
+import com.flint.flint.community.repository.BoardRepository;
+import com.flint.flint.community.spec.BoardType;
+import com.flint.flint.custom_member.WithMockCustomMember;
+import com.flint.flint.member.domain.main.Member;
+import com.flint.flint.member.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@Transactional
+@AutoConfigureMockMvc
+class BoardApiControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private BoardRepository boardRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    private static final String BASE_URL = "/api/v1/boards";
+
+    @Test
+    @DisplayName("학교 인증을 받은 회원이 게시판 즐겨찾기에 등록하면 성공한다.")
+    @WithMockCustomMember
+    void registerBoardBookmark() throws Exception {
+        Board board = Board.builder()
+                .boardType(BoardType.GENERAL)
+                .generalBoardName("자유게시판")
+                .build();
+
+        Board savedBoard = boardRepository.save(board);
+
+        Member member = Member.builder()
+                .name("테스터")
+                .email("test@test.com")
+                .providerName("kakao")
+                .providerId("kakao test")
+                .build();
+
+        memberRepository.save(member);
+
+        this.mockMvc.perform(post(BASE_URL + "/{boardId}/bookmark", savedBoard.getId()))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/flint/flint/community/controller/PostApiControllerTest.java
+++ b/src/test/java/com/flint/flint/community/controller/PostApiControllerTest.java
@@ -44,7 +44,6 @@ class PostApiControllerTest {
 
     @Test
     @DisplayName("학교 인증을 받지 않은 회원은 게시글 생성 시 예외가 발생한다.")
-    @WithMockCustomMember(role = "ROLE_UNAUTHUSER")
     void createPostWithoutCredential() throws Exception {
         Board board = Board.builder()
                 .boardType(BoardType.GENERAL)
@@ -69,7 +68,7 @@ class PostApiControllerTest {
         this.mockMvc.perform(post(BASE_URL)
                         .content(json)
                         .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isInternalServerError());
+                .andExpect(status().isUnauthorized());
     }
 
     @Test
@@ -87,7 +86,7 @@ class PostApiControllerTest {
                 .name("테스터")
                 .email("test@test.com")
                 .providerName("kakao")
-                .providerId("test")
+                .providerId("kakao test")
                 .build();
 
         memberRepository.save(member);

--- a/src/test/java/com/flint/flint/community/service/PostServiceTest.java
+++ b/src/test/java/com/flint/flint/community/service/PostServiceTest.java
@@ -44,7 +44,7 @@ class PostServiceTest {
                 .name("홍길동")
                 .authority(Authority.AUTHUSER)
                 .email("test@test.com")
-                .providerId("test")
+                .providerId("kakao test")
                 .providerName("kakao")
                 .build();
 
@@ -70,7 +70,7 @@ class PostServiceTest {
                 .build();
 
         // when
-        List<PostPreSignedUrlResponse> responses = postService.createPost(savedMember.getEmail(), postRequest);
+        List<PostPreSignedUrlResponse> responses = postService.createPost(savedMember.getProviderId(), postRequest);
 
         List<Post> postList = postRepository.findAll();
 
@@ -92,7 +92,7 @@ class PostServiceTest {
                 .name("홍길동")
                 .authority(Authority.AUTHUSER)
                 .email("test@test.com")
-                .providerId("test")
+                .providerId("kakao test")
                 .providerName("kakao")
                 .build();
 
@@ -117,7 +117,7 @@ class PostServiceTest {
                 .build();
 
         // then, when
-        assertThatThrownBy(() -> postService.createPost(savedMember.getEmail(), postRequest))
+        assertThatThrownBy(() -> postService.createPost(savedMember.getProviderId(), postRequest))
                 .isInstanceOf(FlintCustomException.class)
                 .hasMessage(ResultCode.INVALID_IMAGE_EXTENSION_TYPE.getMessage());
     }

--- a/src/test/java/com/flint/flint/idcard/service/IdCardServiceTest.java
+++ b/src/test/java/com/flint/flint/idcard/service/IdCardServiceTest.java
@@ -51,7 +51,7 @@ class IdCardServiceTest {
                 .providerName("kakao")
                 .email("test2@test.com")
                 .providerId("test2")
-                .authority(Authority.ANAUTHUSER)
+                .authority(Authority.UNAUTHUSER)
                 .build();
 
         memberRepository.save(member);


### PR DESCRIPTION
## 관련 이슈
close #65 
## 변경사항
### Authority Enum 네이밍 변경
- `ANAUTHUSER` -> `UNAUTHUSER`로 변경

### 유저 Provider ID
- Principal 객체를 providerId로 사용함에 따라 기존 테스트 코드 또는 서비스 로직을 그에 맞게 변경
- Member 서비스에 Provider ID로 유저를 조회하는 서비스 메소드 추가
- 
### 모임 생성 컨트롤러 권한 추가
- 컨트롤러에 `@PreAuthorize` 어노테이션 추가하여 인증 추가
- 테스트 코드에서 커스텀 어노테이션 추가

### 즐겨찾기 게시판 API 구현
- 즐겨찾기 게시판 엔티티 정의 (BoardBookmark)
- 게시판 ID를 바탕으로 게시판 즐겨찾기 등록 서비스 로직 추가
  - 이미 해당 게시판을 즐겨찾기 했는지 여부 검증 로직 추가
- 서비스, api 테스트 코드 작성 완료

## 개발하면서 발생한 문제점과 해결방안 또는 새롭게 알게된 점
## 당부하고 싶은 말 또는 논의해봐야할 점
- 즐겨찾기 기능을 하나의 컨트롤러로 토글 형식처럼 등록/해제 하는 방식과 컨트롤러 api 두개로 분리(등록, 해제)하는 방법 중에서 두개로 분리하는 방법을 채택했다.
## 스크린샷
![image](https://github.com/Flint-org/Flint-API-Server/assets/54919474/02434548-8c8f-4106-ae5f-124cec64c3e7)

![image](https://github.com/Flint-org/Flint-API-Server/assets/54919474/5a8c33c7-dc43-4004-a91c-94dc25cfa7ff)

## 기타 및 추후 계획
- 게시판 즐겨찾기 해제 api 구현
- 즐겨찾기한 게시판 목록 조회 api 구현
