### PR TITLE
feat: 게시판 즐겨찾기 해제 API 구현

### DIFF
--- a/src/main/java/com/flint/flint/common/spec/ResultCode.java
+++ b/src/main/java/com/flint/flint/common/spec/ResultCode.java
@@ -33,6 +33,7 @@ public enum ResultCode {
     BOARD_NOT_FOUND("F401", "존재하지 않는 게시판입니다."),
     EXCESS_POST_IMAGE_LIMIT("F402", "게시글의 최대 이미지 개수는 20장입니다."),
     ALREADY_BOOKMARKED_BOARD("F403", "이미 즐겨찾기된 게시판입니다."),
+    UNKNOWN_BOOKMARK_BOARD("F404", "해당 게시판은 즐겨찾기가 되어있지 않습니다."),
 
     // F5xx: 모임 예외
     CLUB_NOT_FOUND_ERROR("F500", "모임을 찾을 수 없습니다."),

--- a/src/main/java/com/flint/flint/community/controller/BoardApiController.java
+++ b/src/main/java/com/flint/flint/community/controller/BoardApiController.java
@@ -34,13 +34,30 @@ public class BoardApiController {
      * @param boardId   즐겨찾기할 게시판 ID
      * @return x
      */
-    @PreAuthorize("hasRole('ROLE_AUTHUSER')")
+    @PreAuthorize("isAuthenticated()")
     @PostMapping("/{boardId}/bookmark")
     public ResponseForm<Void> bookmarkBoard(
             @AuthenticationPrincipal AuthorityMemberDTO memberDTO,
             @PathVariable("boardId") Long boardId
     ) {
         boardService.bookmarkBoard(memberDTO.getProviderId(), boardId);
+        return new ResponseForm<>();
+    }
+
+    /**
+     * 게시판 즐겨찾기 해제
+     *
+     * @param memberDTO 유저
+     * @param boardId   즐겨찾기 해제할 게시판 ID
+     * @return x
+     */
+    @PreAuthorize("isAuthenticated()")
+    @DeleteMapping("/{boardId}/bookmark")
+    public ResponseForm<Void> deleteBookmarkBoard(
+            @AuthenticationPrincipal AuthorityMemberDTO memberDTO,
+            @PathVariable("boardId") Long boardId
+    ) {
+        boardService.deleteBookmarkBoard(memberDTO.getProviderId(), boardId);
         return new ResponseForm<>();
     }
 

--- a/src/main/java/com/flint/flint/community/repository/BoardBookmarkRepository.java
+++ b/src/main/java/com/flint/flint/community/repository/BoardBookmarkRepository.java
@@ -5,6 +5,8 @@ import com.flint.flint.community.domain.board.BoardBookmark;
 import com.flint.flint.member.domain.main.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface BoardBookmarkRepository extends JpaRepository<BoardBookmark, Long> {
-    boolean existsByMemberAndBoard(Member member, Board board);
+    Optional<BoardBookmark> findBoardBookmarkByMemberAndBoard(Member member, Board board);
 }

--- a/src/test/java/com/flint/flint/community/controller/BoardApiControllerTest.java
+++ b/src/test/java/com/flint/flint/community/controller/BoardApiControllerTest.java
@@ -1,7 +1,8 @@
 package com.flint.flint.community.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.flint.flint.community.domain.board.Board;
+import com.flint.flint.community.domain.board.BoardBookmark;
+import com.flint.flint.community.repository.BoardBookmarkRepository;
 import com.flint.flint.community.repository.BoardRepository;
 import com.flint.flint.community.spec.BoardType;
 import com.flint.flint.custom_member.WithMockCustomMember;
@@ -15,7 +16,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -27,6 +28,8 @@ class BoardApiControllerTest {
     private MockMvc mockMvc;
     @Autowired
     private BoardRepository boardRepository;
+    @Autowired
+    private BoardBookmarkRepository boardBookmarkRepository;
     @Autowired
     private MemberRepository memberRepository;
     private static final String BASE_URL = "/api/v1/boards";
@@ -52,6 +55,36 @@ class BoardApiControllerTest {
         memberRepository.save(member);
 
         this.mockMvc.perform(post(BASE_URL + "/{boardId}/bookmark", savedBoard.getId()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("학교 인증을 받은 회원이 즐겨찾기된 게시판을 즐겨찾기 해제하면 성공한다.")
+    @WithMockCustomMember
+    void deleteBoardBookmark() throws Exception {
+        Board board = Board.builder()
+                .boardType(BoardType.GENERAL)
+                .generalBoardName("자유게시판")
+                .build();
+
+        Board savedBoard = boardRepository.save(board);
+
+        Member member = Member.builder()
+                .name("테스터")
+                .email("test@test.com")
+                .providerName("kakao")
+                .providerId("kakao test")
+                .build();
+
+        memberRepository.save(member);
+
+        BoardBookmark bookmark = BoardBookmark.builder()
+                .board(savedBoard)
+                .member(member)
+                .build();
+        boardBookmarkRepository.save(bookmark);
+
+        this.mockMvc.perform(delete(BASE_URL + "/{boardId}/bookmark", savedBoard.getId()))
                 .andExpect(status().isOk());
     }
 }


### PR DESCRIPTION
## 관련 이슈
close #70 
## 변경사항
### 권한 처리
- `@PreAuthorize` 어노테이션의 값을 `hasRole`에서 `isAuthenticated()`로 변경했습니다.

### 즐겨찾기 해제 API 구현
- 예외 처리 및 테스트 코드 작성
- 게시판 즐겨찾기가 되어있는지 아닌지 여부에 대한 검증 메소드 변경
## 개발하면서 발생한 문제점과 해결방안 또는 새롭게 알게된 점
x
## 당부하고 싶은 말 또는 논의해봐야할 점
x
## 스크린샷
![image](https://github.com/Flint-org/Flint-API-Server/assets/54919474/eb97578b-2fdf-4f4f-88ac-cbd559df4a14)

## 기타 및 추후 계획

