### PR TITLE
Feat: 댓글/대댓글 생성, 수정, 삭제 구현

### DIFF
--- a/src/main/java/com/flint/flint/common/spec/ResultCode.java
+++ b/src/main/java/com/flint/flint/common/spec/ResultCode.java
@@ -33,6 +33,9 @@ public enum ResultCode {
     BOARD_NOT_FOUND("F401", "존재하지 않는 게시판입니다."),
     EXCESS_POST_IMAGE_LIMIT("F402", "게시글의 최대 이미지 개수는 20장입니다."),
     ALREADY_BOOKMARKED_BOARD("F403", "이미 즐겨찾기된 게시판입니다."),
+    POST_NOT_FOUND("404", "존재하지 않는 게시글입니다."),
+    POST_COMMENT_NOT_FOUND("405", "존재하지 않는 게시글 댓글입니다."),
+    POST_COMMENT_NOT_WRITER("406", "글쓴이가 아닙니다."),
 
     // F5xx: 모임 예외
     CLUB_NOT_FOUND_ERROR("F500", "모임을 찾을 수 없습니다."),

--- a/src/main/java/com/flint/flint/community/controller/PostCommentUpdateController.java
+++ b/src/main/java/com/flint/flint/community/controller/PostCommentUpdateController.java
@@ -1,0 +1,45 @@
+package com.flint.flint.community.controller;
+
+import com.flint.flint.common.ResponseForm;
+import com.flint.flint.community.dto.request.PostCommentUpdateRequest;
+import com.flint.flint.community.dto.response.PostCommentCreateResponse;
+import com.flint.flint.community.service.PostCommentUpdateService;
+import com.flint.flint.security.auth.dto.AuthorityMemberDTO;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * @author 정순원
+ * @since 2023-09-30
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/posts/comment")
+@PreAuthorize("hasRole('ROLE_AUTHUSER')")
+public class PostCommentUpdateController {
+
+    private final PostCommentUpdateService postService;
+
+    @PostMapping("/{postId}/reply")
+    public ResponseForm<PostCommentCreateResponse> createPostComment(
+            @AuthenticationPrincipal AuthorityMemberDTO memberDTO, @PathVariable long postId,
+            @Valid @RequestBody PostCommentUpdateRequest requestDTO) {
+        return new ResponseForm<>(postService.createPostComment(memberDTO.getProviderId(), postId, requestDTO));
+    }
+    @DeleteMapping("/{postCommentId}")
+    public ResponseForm deletePostComment(@AuthenticationPrincipal AuthorityMemberDTO memberDTO, @PathVariable long postCommentId) {
+        postService.deletePostComment(memberDTO.getProviderId(), postCommentId);
+        return new ResponseForm<>();
+    }
+
+    @PutMapping("/{postCommentId}")
+    public ResponseForm updatePostComment(@AuthenticationPrincipal AuthorityMemberDTO memberDTO, @PathVariable long postCommentId,
+                                          @Valid @RequestBody PostCommentUpdateRequest request) {
+        postService.updatePostComment(memberDTO.getProviderId(), postCommentId, request);
+        return new ResponseForm<>();
+    }
+}
+

--- a/src/main/java/com/flint/flint/community/domain/post/PostComment.java
+++ b/src/main/java/com/flint/flint/community/domain/post/PostComment.java
@@ -1,6 +1,7 @@
 package com.flint.flint.community.domain.post;
 
 import com.flint.flint.common.BaseTimeEntity;
+import com.flint.flint.community.dto.request.PostCommentUpdateRequest;
 import com.flint.flint.member.domain.main.Member;
 import jakarta.persistence.*;
 import lombok.Builder;
@@ -35,7 +36,7 @@ public class PostComment extends BaseTimeEntity {
     private PostComment parentComment;
 
     @OneToMany(mappedBy = "parentComment", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<PostComment> replies = new ArrayList<>();
+    private List<PostComment> replies;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
@@ -49,7 +50,19 @@ public class PostComment extends BaseTimeEntity {
         this.post = post;
         this.parentComment = parentComment;
         this.member = member;
-        this.replies = replies;
+        this.replies = new ArrayList<>();
+        this.contents = contents;
+    }
+
+    public void setParentComment(PostComment parentComment) {
+        this.parentComment = parentComment;
+    }
+    public void addCommentReply(PostComment reply) {
+        this.replies.add(reply);
+        reply.setParentComment(this);
+    }
+
+    public void updateContent(String contents) {
         this.contents = contents;
     }
 }

--- a/src/main/java/com/flint/flint/community/dto/request/PostCommentUpdateRequest.java
+++ b/src/main/java/com/flint/flint/community/dto/request/PostCommentUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.flint.flint.community.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostCommentUpdateRequest {
+
+        @NotBlank
+        private String contents;
+
+        private long parentCommentId;
+}

--- a/src/main/java/com/flint/flint/community/dto/response/PostCommentCreateResponse.java
+++ b/src/main/java/com/flint/flint/community/dto/response/PostCommentCreateResponse.java
@@ -1,0 +1,13 @@
+package com.flint.flint.community.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostCommentCreateResponse {
+
+    private long postCommentId;
+}

--- a/src/main/java/com/flint/flint/community/repository/PostCommentRepository.java
+++ b/src/main/java/com/flint/flint/community/repository/PostCommentRepository.java
@@ -1,0 +1,11 @@
+package com.flint.flint.community.repository;
+
+import com.flint.flint.community.domain.post.Post;
+import com.flint.flint.community.domain.post.PostComment;
+import com.flint.flint.member.domain.main.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostCommentRepository extends JpaRepository<PostComment, Long> {
+
+    PostComment findPostCommentById(Long id);
+}

--- a/src/main/java/com/flint/flint/community/service/PostCommentUpdateService.java
+++ b/src/main/java/com/flint/flint/community/service/PostCommentUpdateService.java
@@ -1,0 +1,76 @@
+package com.flint.flint.community.service;
+
+import com.flint.flint.common.exception.FlintCustomException;
+import com.flint.flint.common.spec.ResultCode;
+import com.flint.flint.community.domain.post.Post;
+import com.flint.flint.community.domain.post.PostComment;
+import com.flint.flint.community.dto.request.PostCommentUpdateRequest;
+import com.flint.flint.community.dto.response.PostCommentCreateResponse;
+import com.flint.flint.community.repository.PostCommentRepository;
+import com.flint.flint.community.repository.PostRepository;
+import com.flint.flint.member.domain.main.Member;
+import com.flint.flint.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+/**
+ * @author 정순원
+ * @since 2023-10-04
+ */
+@Service
+@RequiredArgsConstructor
+public class PostCommentUpdateService {
+
+    private final PostCommentRepository postCommentRepository;
+    private final MemberService memberService;
+    private final PostRepository postRepository;
+
+    @Transactional
+    public PostCommentCreateResponse createPostComment(String providerId, long postId, PostCommentUpdateRequest createDTO) {
+        PostComment postComment = buildPostComment(providerId, postId, createDTO);
+        PostComment parentComment = postCommentRepository.findPostCommentById(createDTO.getParentCommentId());
+
+        if (parentComment == null) { // 댓글일시
+            postComment.setParentComment(null);
+        } else{                      //대댓글일시
+            parentComment.addCommentReply(postComment);
+        }
+        postCommentRepository.save(postComment);
+        return new PostCommentCreateResponse(postComment.getId());
+    }
+
+    @Transactional
+    public void deletePostComment(String providerId, long postCommentId) {
+        isWriter(providerId, postCommentId);  //글쓴이가 맞는지
+        postCommentRepository.deleteById(postCommentId);
+    }
+
+    @Transactional
+    public void updatePostComment(String providerId, long postCommentId, PostCommentUpdateRequest updateRequest) {
+        isWriter(providerId, postCommentId);
+        PostComment postComment = postCommentRepository.findById(postCommentId).orElseThrow(() -> new FlintCustomException(HttpStatus.NOT_FOUND, ResultCode.POST_COMMENT_NOT_FOUND));
+        postComment.updateContent(updateRequest.getContents());
+    }
+
+    private PostComment buildPostComment(String providerId, long postId, PostCommentUpdateRequest createDTO) {
+        Member member = memberService.getMemberByProviderId(providerId);
+        Post post = postRepository.findById(postId).orElseThrow(() -> new FlintCustomException(HttpStatus.NOT_FOUND, ResultCode.POST_NOT_FOUND));
+
+        return PostComment.builder()
+                .member(member)
+                .post(post)
+                .contents(createDTO.getContents())
+                .build();
+    }
+
+    private void isWriter(String providerId, long postCommentId) {
+        PostComment postComment = postCommentRepository.findById(postCommentId).orElseThrow(() -> new FlintCustomException(HttpStatus.NOT_FOUND, ResultCode.POST_COMMENT_NOT_FOUND));
+        if (providerId != postComment.getMember().getProviderId()) {
+            throw new FlintCustomException(HttpStatus.FORBIDDEN, ResultCode.POST_COMMENT_NOT_WRITER);
+        }
+    }
+}

--- a/src/test/java/com/flint/flint/community/service/PostCommentUpdateServiceTest.java
+++ b/src/test/java/com/flint/flint/community/service/PostCommentUpdateServiceTest.java
@@ -1,0 +1,111 @@
+package com.flint.flint.community.service;
+
+import com.flint.flint.common.exception.FlintCustomException;
+import com.flint.flint.common.spec.ResultCode;
+import com.flint.flint.community.domain.post.Post;
+import com.flint.flint.community.domain.post.PostComment;
+import com.flint.flint.community.dto.request.PostCommentUpdateRequest;
+import com.flint.flint.community.dto.response.PostCommentCreateResponse;
+import com.flint.flint.community.repository.PostCommentRepository;
+import com.flint.flint.community.repository.PostRepository;
+import com.flint.flint.member.domain.main.Member;
+import com.flint.flint.member.repository.MemberRepository;
+import com.flint.flint.member.service.MemberService;
+import com.flint.flint.member.spec.Authority;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+class PostCommentUpdateServiceTest {
+
+    @Autowired
+    PostCommentRepository postCommentRepository;
+    @Autowired
+    PostRepository postRepository;
+    @Autowired
+    PostCommentUpdateService postCommentUpdateService;
+    @Autowired
+    MemberService memberService;
+    @Autowired
+    MemberRepository memberRepository;
+
+    Post post;
+    PostComment parentComment;
+
+    @BeforeEach
+    void setUp() {
+        Member member = Member.builder()
+                .name("정순원")
+                .authority(Authority.AUTHUSER)
+                .email("test@test.com")
+                .providerName("kakao")
+                .providerId("kakao test")
+                .build();
+
+        memberRepository.save(member);
+
+        post = Post.builder()
+                .title("테스트제목")
+                .contents("테스트내용")
+                .build();
+
+        postRepository.save(post);
+
+        parentComment = PostComment.builder()
+                .contents("부모댓글 테스트내용")
+                .post(post)
+                .member(member)
+                .build();
+
+        postCommentRepository.save(parentComment);
+    }
+
+    @Test
+    @DisplayName("커뮤니티 댓글 생성 테스트")
+    @Transactional
+    void test1() {
+        //given
+        PostCommentUpdateRequest requestDTO = PostCommentUpdateRequest.builder()
+                .contents("댓글 테스트내용입니다.")
+                .build();
+        //when
+        PostCommentCreateResponse responseDTO = postCommentUpdateService.createPostComment("kakao test", post.getId(), requestDTO);
+        //then
+        PostComment postComment = postCommentRepository.findById(responseDTO.getPostCommentId()).orElseThrow(() -> new FlintCustomException(HttpStatus.NOT_FOUND, ResultCode.POST_COMMENT_NOT_FOUND));
+        assertEquals(requestDTO.getContents(), postComment.getContents());
+    }
+
+    @Test
+    @DisplayName("커뮤니티 대댓글 생성 테스트")
+    @Transactional
+    void test2() {
+        //given
+        PostCommentUpdateRequest requestDTO = new PostCommentUpdateRequest("대댓글 테스트내용입니다.", parentComment.getId());
+        //when
+        PostCommentCreateResponse responseDTO = postCommentUpdateService.createPostComment("kakao test", post.getId(), requestDTO);
+        //then
+        PostComment reply = postCommentRepository.findById(responseDTO.getPostCommentId()).orElseThrow(() -> new FlintCustomException(HttpStatus.NOT_FOUND, ResultCode.POST_COMMENT_NOT_FOUND));
+        assertEquals(requestDTO.getContents(), reply.getContents());
+        assertEquals(reply, parentComment.getReplies().get(0));
+        assertEquals(parentComment, reply.getParentComment());
+    }
+
+    @Test
+    @DisplayName("커뮤니티 댓글 삭제 테스트")
+    @Transactional
+    void test3() {
+        //given
+
+        //when
+        postCommentUpdateService.deletePostComment("kakao test", parentComment.getId());
+        //then
+        assertEquals(0, postCommentRepository.findAll().size());
+    }
+}

--- a/src/test/java/com/flint/flint/custom_member/WithMockCustomMember.java
+++ b/src/test/java/com/flint/flint/custom_member/WithMockCustomMember.java
@@ -16,3 +16,4 @@ import java.lang.annotation.RetentionPolicy;
 public @interface WithMockCustomMember {
     String role() default "ROLE_AUTHUSER";
 }
+    


### PR DESCRIPTION
## 관련 이슈
close #76 
## 변경사항
- 댓글이랑 대댓글이랑 하나의 API로 처리했습니다
  - 생성 API
  - 삭제 API
  - 수정 API

## 개발하면서 발생한 문제점과 해결방안 또는 새롭게 알게된 점

![image](https://github.com/Flint-org/Flint-API-Server/assets/92251131/3f055e02-7ff3-4c98-9cea-b433c101df5f)
![image](https://github.com/Flint-org/Flint-API-Server/assets/92251131/c037e360-091f-4138-babd-c20cb93654fb)

## 당부하고 싶은 말 또는 논의해봐야할 점
## 스크린샷
![image](https://github.com/Flint-org/Flint-API-Server/assets/92251131/8daff653-d03e-4e9d-890f-f7eb244cd97d)

## 기타 및 추후 계획

