### PR TITLE
Feat: 댓글/대댓글 좋아요 좋아요/취소 API 구현

### DIFF
--- a/src/main/java/com/flint/flint/community/controller/PostCommentUpdateController.java
+++ b/src/main/java/com/flint/flint/community/controller/PostCommentUpdateController.java
@@ -3,6 +3,7 @@ package com.flint.flint.community.controller;
 import com.flint.flint.common.ResponseForm;
 import com.flint.flint.community.dto.request.PostCommentUpdateRequest;
 import com.flint.flint.community.dto.response.PostCommentUpdateResponse;
+import com.flint.flint.community.service.PostCommentLikeUpdateService;
 import com.flint.flint.community.service.PostCommentUpdateService;
 import com.flint.flint.security.auth.dto.AuthorityMemberDTO;
 import jakarta.validation.Valid;
@@ -21,24 +22,31 @@ import org.springframework.web.bind.annotation.*;
 @PreAuthorize("hasRole('ROLE_AUTHUSER')")
 public class PostCommentUpdateController {
 
-    private final PostCommentUpdateService postService;
+    private final PostCommentUpdateService postCommentUpdateService;
+    private final PostCommentLikeUpdateService postCommentLikeUpdateService;
 
     @PostMapping("/{postId}")
     public ResponseForm<PostCommentUpdateResponse> createPostComment(
             @AuthenticationPrincipal AuthorityMemberDTO memberDTO, @PathVariable long postId,
             @Valid @RequestBody PostCommentUpdateRequest requestDTO) {
-        return new ResponseForm<>(postService.createPostComment(memberDTO.getProviderId(), postId, requestDTO));
+        return new ResponseForm<>(postCommentUpdateService.createPostComment(memberDTO.getProviderId(), postId, requestDTO));
     }
     @DeleteMapping("/{postCommentId}")
     public ResponseForm deletePostComment(@AuthenticationPrincipal AuthorityMemberDTO memberDTO, @PathVariable long postCommentId) {
-        postService.deletePostComment(memberDTO.getProviderId(), postCommentId);
+        postCommentUpdateService.deletePostComment(memberDTO.getProviderId(), postCommentId);
         return new ResponseForm<>();
     }
 
     @PutMapping("/{postCommentId}")
     public ResponseForm updatePostComment(@AuthenticationPrincipal AuthorityMemberDTO memberDTO, @PathVariable long postCommentId,
                                           @Valid @RequestBody PostCommentUpdateRequest request) {
-        postService.updatePostComment(memberDTO.getProviderId(), postCommentId, request);
+        postCommentUpdateService.updatePostComment(memberDTO.getProviderId(), postCommentId, request);
+        return new ResponseForm<>();
+    }
+
+    @PostMapping("/{postCommentId}")
+    public ResponseForm createPostCommentLike (@AuthenticationPrincipal AuthorityMemberDTO memberDTO, @PathVariable long postCommentId) {
+        postCommentLikeUpdateService.createPostCommentLike(memberDTO.getProviderId(), postCommentId);
         return new ResponseForm<>();
     }
 }

--- a/src/main/java/com/flint/flint/community/repository/PostCommentLikeRepository.java
+++ b/src/main/java/com/flint/flint/community/repository/PostCommentLikeRepository.java
@@ -1,0 +1,18 @@
+package com.flint.flint.community.repository;
+
+import com.flint.flint.community.domain.post.PostCommentLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+/**
+ * @author 정순원
+ * @since 2023-10-11
+ */
+public interface PostCommentLikeRepository extends JpaRepository<PostCommentLike, Long> {
+
+    @Query("SELECT pcl FROM PostCommentLike pcl JOIN pcl.member m WHERE m.providerId = :providerId AND pcl.postComment.id = :postCommentId")
+    Optional<PostCommentLike> findByProviderIdAndPostCommentId(@Param("providerId") String providerId, @Param("postCommentId") Long postCommentId);
+}

--- a/src/main/java/com/flint/flint/community/service/PostCommentLikeUpdateService.java
+++ b/src/main/java/com/flint/flint/community/service/PostCommentLikeUpdateService.java
@@ -1,0 +1,42 @@
+package com.flint.flint.community.service;
+
+import com.flint.flint.common.exception.FlintCustomException;
+import com.flint.flint.common.spec.ResultCode;
+import com.flint.flint.community.domain.post.PostComment;
+import com.flint.flint.community.domain.post.PostCommentLike;
+import com.flint.flint.community.repository.PostCommentLikeRepository;
+import com.flint.flint.community.repository.PostCommentRepository;
+import com.flint.flint.member.domain.main.Member;
+import com.flint.flint.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+/**
+ * @author 정순원
+ * @since 2023-10-11
+ */
+@Service
+@RequiredArgsConstructor
+public class PostCommentLikeUpdateService {
+
+    private final PostCommentLikeRepository postCommentLikeRepository;
+    private final MemberService memberService;
+    private final PostCommentRepository postCommentRepository;
+
+    public void createPostCommentLike(String provierId, long postCommentId) {
+        Optional<PostCommentLike> OptionalCommentLike = postCommentLikeRepository.findByProviderIdAndPostCommentId(provierId, postCommentId);
+        if(!OptionalCommentLike.isPresent()) {  //이전에 좋아요를 안했을 때
+            Member member = memberService.getMemberByProviderId(provierId);
+            PostComment postComment = postCommentRepository.findById(postCommentId).orElseThrow(() -> new FlintCustomException(HttpStatus.NOT_FOUND, ResultCode.POST_COMMENT_NOT_FOUND));
+            PostCommentLike build = PostCommentLike.builder()
+                    .member(member)
+                    .postComment(postComment)
+                    .build();
+            postCommentLikeRepository.save(build);
+        }
+        else postCommentLikeRepository.delete(OptionalCommentLike.get()); // 이전에 좋아요를 했을 때
+    }
+}

--- a/src/test/java/com/flint/flint/community/service/PostCommentLikeUpdateServiceTest.java
+++ b/src/test/java/com/flint/flint/community/service/PostCommentLikeUpdateServiceTest.java
@@ -1,0 +1,72 @@
+package com.flint.flint.community.service;
+
+import com.flint.flint.community.domain.post.PostComment;
+import com.flint.flint.community.domain.post.PostCommentLike;
+import com.flint.flint.community.repository.PostCommentLikeRepository;
+import com.flint.flint.community.repository.PostCommentRepository;
+import com.flint.flint.member.domain.main.Member;
+import com.flint.flint.member.service.MemberService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class PostCommentLikeUpdateServiceTest {
+
+    @InjectMocks
+    private PostCommentLikeUpdateService postCommentLikeUpdateService;
+
+    @Mock
+    private PostCommentLikeRepository postCommentLikeRepository;
+
+    @Mock
+    private MemberService memberService;
+
+    @Mock
+    private PostCommentRepository postCommentRepository;
+
+
+    @Test
+    @DisplayName("기존에 좋아요가 없을 때 좋아요 생성 테스트")
+    public void test1() {
+        // given
+        String providerId = "someProviderId";
+        long postCommentId = 1L;
+
+        when(postCommentLikeRepository.findByProviderIdAndPostCommentId(providerId, postCommentId)).thenReturn(Optional.empty());
+        when(memberService.getMemberByProviderId(providerId)).thenReturn(new Member());
+        when(postCommentRepository.findById(postCommentId)).thenReturn(Optional.of(new PostComment()));
+
+        // when
+        postCommentLikeUpdateService.createPostCommentLike(providerId, postCommentId);
+
+        // then
+        verify(postCommentLikeRepository, times(1)).save(any(PostCommentLike.class));
+        verify(postCommentLikeRepository, never()).delete(any(PostCommentLike.class));
+    }
+
+    @Test
+    @DisplayName("기존에 좋아요가 있을 때 좋아요 삭제 테스트")
+    public void test2() {
+        // given
+        String providerId = "someProviderId";
+        long postCommentId = 1L;
+
+        when(postCommentLikeRepository.findByProviderIdAndPostCommentId(providerId, postCommentId)).thenReturn(Optional.of(new PostCommentLike()));
+
+        // when
+        postCommentLikeUpdateService.createPostCommentLike(providerId, postCommentId);
+
+        // then
+        verify(postCommentLikeRepository, never()).save(any(PostCommentLike.class));
+        verify(postCommentLikeRepository, times(1)).delete(any(PostCommentLike.class));
+    }
+}


### PR DESCRIPTION
최근 pr 올라간 브랜치에서 파생된 브랜치라 커밋이 겹칩니다. commentlike 관련 클래스만 보시면 됩니당

## 관련 이슈
close #82 
## 변경사항
- 댓글/대댓글 좋아요/취소 API 구현
## 개발하면서 발생한 문제점과 해결방안 또는 새롭게 알게된 점

좋아요를 했는지 판단하는 메소드를 작성 중입니다

![image](https://github.com/Flint-org/Flint-API-Server/assets/92251131/301208e7-2670-4d32-a4db-f918d24b47e5)

사용자의 providerId를 받아서 사용자 엔티티를 찾아오고

댓글 Id를 받아와서 댓글 엔티티를 찾아온 후 

JPA 쿼리메소드인 findByMemberAndComment로  postCommentLike 객체를 찾으려고했니다.

## 의아한 점

이런 비슷한 API 코드를 작성할 때 이러한 문제들을 은연중 느꼈던 것 같습니다.

바로, 그 문제는 **‘id가 있는데 꼭 엔티티로 필요한 도메인을 찾아야 하나?’** 입니다.

## 문제점

1. 데이터베이스 필드에는 객체가 엔티티가 아닌 id로 저장되어있습니다. 

프론트엔드에게 id를 받았지만 객체를 찾는 과정을 거쳐서 필요한 도메인을 찾는 것은 **생산적이지 못한 일**이라 생각들었습니다.

1. **불필요한 select이 세 번 발생한다**
id로 찾는다면 select이 한 번 발생하지만
객체로 찾는다면 member를 찾기위한 select 한 번, 댓글을 찾기 위한 select 한번, commentLike를 찾기 위한 select 한 번.

1. **다른 클래스와의 연관성이 깊어진다.**
member를 찾기위한 memberService, commet를 찾기 위한 commentRepository와의 관계성이 추가 되기 때문에 안 좋은 코드라 생각합니다.  

1. **N+1 문제**
조인을 사용하지 않고 여러 쿼리를 수행하여 필요한 데이터를 가져오는 방식은 종종 N+1 문제를 야기할 수 있습니다.

##해결법

JPA쿼리 메소드를 쓰려면  객체가 필요합니다.

그래서 쿼리 dsl 혹은 @Query 메소드를 이용해야 합니다.

간단한 쿼리문이라 생각해서 @Query를 사용했습니다.

```java
public interface PostCommentLikeRepository extends JpaRepository<PostCommentLike, Long> {

    @Query("SELECT pcl FROM PostCommentLike pcl JOIN pcl.member m WHERE m.providerId = :providerId AND pcl.postComment.id = :postCommentId")
    Optional<PostCommentLike> findByProviderIdAndPostCommentId(@Param("providerId") String providerId, @Param("postCommentId") Long postCommentId);
}
```

---
## 당부하고 싶은 말 또는 논의해봐야할 점

- 좋아요를 했는지 안 했는지는 hasLike() 메소드를 따로 파서 만들어야 하는 거 아닌가?
- ‘이전에 좋아요를 안 했을 때’ 케이스에서  postCommentLike 엔티티를 생성해야 되기 때문에 결국 member와 postComment 객체가 생성됐다. 객체를 저장할 때도 id 값만로 해야 하나?
- 프론트에게 postCommentId 값을 넘겨봤는데 db에 해당하는 id 값의 postComment가 있는지 확인해야 하나?
    - 결국 값 존재 유무도 확인해야 하고 ‘이전에 좋아요를 안 했을 때’ 케이스에서 엔티티를 생성해야 되는데 굳이 member, postComment id 값들로 쿼리를 만들어야 하나?
## 스크린샷
![image](https://github.com/Flint-org/Flint-API-Server/assets/92251131/b0746ec2-610e-44c9-95e9-10f27a9b03f7)

## 기타 및 추후 계획
- 매번, 테스트코드 데이터 셋업에서 엔티티를 만드는 과정이 비생산적인 생각이 들었습니다.  헬퍼 클래스를 구현하여 createMember 등 엔티티를 생성하는 메소드를 만들 예정입니다. 
