### PR TITLE
refactor: 전공 게시판 소분류에 대해 공통 게시판 ID 부여에 따른 수정

### DIFF
--- a/src/main/java/com/flint/flint/community/domain/board/MajorBoard.java
+++ b/src/main/java/com/flint/flint/community/domain/board/MajorBoard.java
@@ -27,7 +27,7 @@ public class MajorBoard extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "BOARD_ID")
-    private Board board; // child 의 경우 null
+    private Board board; // child도 가지도록 변경 (2023-10-13)
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "UPPER_BOARD_ID")

--- a/src/main/java/com/flint/flint/community/dto/response/LowerMajorBoardResponse.java
+++ b/src/main/java/com/flint/flint/community/dto/response/LowerMajorBoardResponse.java
@@ -6,18 +6,19 @@ import lombok.NoArgsConstructor;
 
 /**
  * 소분류 전공 게시판 조회 결과 DTO
+ *
  * @author 신승건
  * @since 2023-08-21
  */
 @Data
 @NoArgsConstructor
 public class LowerMajorBoardResponse {
-    private Long lowerMajorId;
+    private Long boardId;
     private String lowerMajorName;
 
     @Builder
-    public LowerMajorBoardResponse(Long lowerMajorId, String lowerMajorName) {
-        this.lowerMajorId = lowerMajorId;
+    public LowerMajorBoardResponse(Long boardId, String lowerMajorName) {
+        this.boardId = boardId;
         this.lowerMajorName = lowerMajorName;
     }
 }

--- a/src/main/java/com/flint/flint/community/service/BoardService.java
+++ b/src/main/java/com/flint/flint/community/service/BoardService.java
@@ -68,7 +68,7 @@ public class BoardService {
                         .upperMajorName(major.getName())
                         .lowerMajors(major.getLowerMajorBoards().stream().map( // parent로부터 소분류 전공 게시판 가져오기
                                         lower -> LowerMajorBoardResponse.builder()
-                                                .lowerMajorId(lower.getId())
+                                                .boardId(lower.getBoard().getId())
                                                 .lowerMajorName(lower.getName())
                                                 .build()
                                 ).toList()
@@ -113,7 +113,7 @@ public class BoardService {
                 .upperMajorId(upperMajor.getId())
                 .upperMajorName(upperMajor.getName())
                 .lowerMajors(lowerMajors.stream().map(lower -> LowerMajorBoardResponse.builder()
-                                .lowerMajorId(lower.getId())
+                                .boardId(lower.getBoard().getId())
                                 .lowerMajorName(lower.getName())
                                 .build())
                         .toList())

--- a/src/test/java/com/flint/flint/community/service/BoardServiceTest.java
+++ b/src/test/java/com/flint/flint/community/service/BoardServiceTest.java
@@ -74,9 +74,34 @@ class BoardServiceTest {
                 .generalBoardName(null)
                 .build();
 
+        Board majorBoard4 = Board.builder().boardType(BoardType.MAJOR)
+                .generalBoardName(null)
+                .build();
+
+        Board majorBoard5 = Board.builder().boardType(BoardType.MAJOR)
+                .generalBoardName(null)
+                .build();
+
+        Board majorBoard6 = Board.builder().boardType(BoardType.MAJOR)
+                .generalBoardName(null)
+                .build();
+
+        Board majorBoard7 = Board.builder().boardType(BoardType.MAJOR)
+                .generalBoardName(null)
+                .build();
+
+        Board majorBoard8 = Board.builder().boardType(BoardType.MAJOR)
+                .generalBoardName(null)
+                .build();
+
         boardRepository.save(majorBoard1);
         boardRepository.save(majorBoard2);
         boardRepository.save(majorBoard3);
+        boardRepository.save(majorBoard4);
+        boardRepository.save(majorBoard5);
+        boardRepository.save(majorBoard6);
+        boardRepository.save(majorBoard7);
+        boardRepository.save(majorBoard8);
 
         MajorBoard major1 = MajorBoard.builder()
                 .board(majorBoard1)
@@ -101,34 +126,34 @@ class BoardServiceTest {
         MajorBoard savedMajor3 = majorBoardRepository.save(major3);
 
         MajorBoard lower11 = MajorBoard.builder()
-                .board(null)
+                .board(majorBoard4)
                 .name("건축")
                 .upperMajorBoard(savedMajor1)
                 .lowerMajorBoards(null)
                 .build();
         MajorBoard lower12 = MajorBoard.builder()
-                .board(null)
+                .board(majorBoard5)
                 .name("기계 금속")
                 .upperMajorBoard(savedMajor1)
                 .lowerMajorBoards(null)
                 .build();
 
         MajorBoard lower21 = MajorBoard.builder()
-                .board(null)
+                .board(majorBoard6)
                 .name("경영 경제")
                 .upperMajorBoard(savedMajor2)
                 .lowerMajorBoards(null)
                 .build();
 
         MajorBoard lower22 = MajorBoard.builder()
-                .board(null)
+                .board(majorBoard7)
                 .name("법률")
                 .upperMajorBoard(savedMajor2)
                 .lowerMajorBoards(null)
                 .build();
 
         MajorBoard lower31 = MajorBoard.builder()
-                .board(null)
+                .board(majorBoard8)
                 .name("교육일반")
                 .upperMajorBoard(savedMajor3)
                 .lowerMajorBoards(null)
@@ -224,7 +249,7 @@ class BoardServiceTest {
     @Test
     void checkNotExistUpperMajor() {
         // given
-        Long upperMajorID = 1000000L;
+        Long upperMajorID = -1L;
 
         // when, then
         assertThatThrownBy(() -> boardService.getLowerMajorListByUpperMajor(upperMajorID))


### PR DESCRIPTION
## 관련 이슈
close #85 
## 변경사항
### 게시판 설계 수정
- As Is
  - 전공 게시판 중에서도 대분류 전공 게시판에 대해서만 board_id를 부여받았습니다. 
  - 그러다 보니 게시판 전체 범위에 대한 접근 관련 기능을 구현할 때는 소분류 전공 게시판에 접근할 수 있는 방법이 없어서 문제가 발생했습니다.
  - **Board 테이블에는 대분류 데이터만 저장됨**
  - **MajorBoard 테이블에서 소분류 게시판인 경우, board_id 필드는 null**
- To Be
  - 소분류 전공 게시판도 board_id를 부여받을 수 있도록 하여 게시판 전체 범위에 대한 접근을 가능하게끔 하였습니다. 
  - **Board 테이블에도 소분류 데이터를 저장**
  - **MajorBoard 테이블에서 소분류 게시판에 위에 저장한 board_id 필드 값 부여**

- 그래서 실질적으로 코드상으로 수정한 부분은 많이 없고, 논리적인 설계를 변경함에 따라 현재 데이터베이스에 저장된 게시판 데이터를 위처럼 수정하였습니다. 

- 코드 상에서 수정한 부분은 소분류 전공 게시판에 board_id 값을 부여해주는 부분과 소분류 전공 게시판에 접근 가능하게끔 게시판 조회할 때, 소분류 전공 게시판에 board_id 필드도 함께 전달해주도록 했습니다. 
## 개발하면서 발생한 문제점과 해결방안 또는 새롭게 알게된 점
- Board 테이블에 insert, MajorBoard 테이블에 update를 하는 쿼리를 저장된 만큼 반복해야되는데 이를 하나하나 쿼리문을 날리는 것이 비효율적이여서 MySQL의 while 루프와 procedure 기능을 사용하여 반복 수행을 처리했습니다.
```sql
 DELIMITER $$
 CREATE PROCEDURE update_major_board()
 BEGIN
   DECLARE start_id INT;
   DECLARE end_id INT;
   
   SET start_id = 13; -- 시작 major_board_id
   SET end_id = 47;   -- 끝 major_board_id

   WHILE start_id <= end_id DO
     -- INSERT 문 실행
     INSERT INTO board(board_type, general_board_name, created_at, updated_at) VALUES('MAJOR', null, NOW(), NOW());
     
     -- UPDATE 문 실행
     UPDATE major_board SET board_id = (start_id + 5) WHERE major_board_id = start_id;
     
     SET start_id = start_id + 1;
   END WHILE;
END$$
DELIMITER ;
-- 프로시저 호출
CALL update_major_board();
```
## 당부하고 싶은 말 또는 논의해봐야할 점
- 너무 대충 설계했던 것 같네요. 기존 저장된 데이터도 문제가 있었네요
## 스크린샷
![image](https://github.com/Flint-org/Flint-API-Server/assets/54919474/7384391c-322a-4409-a9c0-071360026a5a)

## 기타 및 추후 계획

