### PR TITLE
Feat: 게시글 좋아요 API 구현

### DIFF
--- a/src/main/java/com/flint/flint/community/controller/PostApiController.java
+++ b/src/main/java/com/flint/flint/community/controller/PostApiController.java
@@ -2,17 +2,16 @@ package com.flint.flint.community.controller;
 
 import com.flint.flint.common.ResponseForm;
 import com.flint.flint.community.dto.request.PostRequest;
+import com.flint.flint.community.dto.response.PostLikeResponse;
 import com.flint.flint.community.dto.response.PostPreSignedUrlResponse;
+import com.flint.flint.community.service.PostLikeUpdateService;
 import com.flint.flint.community.service.PostService;
 import com.flint.flint.security.auth.dto.AuthorityMemberDTO;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -25,6 +24,8 @@ import java.util.List;
 @RequestMapping("/api/v1/posts")
 public class PostApiController {
     private final PostService postService;
+    private final PostLikeUpdateService postLikeUpdateService;
+
 
     @PreAuthorize("hasRole('ROLE_AUTHUSER')")
     @PostMapping("")
@@ -33,5 +34,10 @@ public class PostApiController {
             @Valid @RequestBody PostRequest postRequest
     ) {
         return new ResponseForm<>(postService.createPost(memberDTO.getProviderId(), postRequest));
+    }
+
+    @PostMapping("/heart/{postId}")
+    public ResponseForm<PostLikeResponse> createPostLike(@AuthenticationPrincipal AuthorityMemberDTO memberDTO, @PathVariable long postId) {
+        return new ResponseForm<>(postLikeUpdateService.createPostLike(memberDTO.getProviderId(), postId));
     }
 }

--- a/src/main/java/com/flint/flint/community/controller/PostCommentUpdateController.java
+++ b/src/main/java/com/flint/flint/community/controller/PostCommentUpdateController.java
@@ -2,6 +2,7 @@ package com.flint.flint.community.controller;
 
 import com.flint.flint.common.ResponseForm;
 import com.flint.flint.community.dto.request.PostCommentUpdateRequest;
+import com.flint.flint.community.dto.response.PostCommentLikeResponse;
 import com.flint.flint.community.dto.response.PostCommentUpdateResponse;
 import com.flint.flint.community.service.PostCommentLikeUpdateService;
 import com.flint.flint.community.service.PostCommentUpdateService;
@@ -31,6 +32,7 @@ public class PostCommentUpdateController {
             @Valid @RequestBody PostCommentUpdateRequest requestDTO) {
         return new ResponseForm<>(postCommentUpdateService.createPostComment(memberDTO.getProviderId(), postId, requestDTO));
     }
+
     @DeleteMapping("/{postCommentId}")
     public ResponseForm deletePostComment(@AuthenticationPrincipal AuthorityMemberDTO memberDTO, @PathVariable long postCommentId) {
         postCommentUpdateService.deletePostComment(memberDTO.getProviderId(), postCommentId);
@@ -44,10 +46,9 @@ public class PostCommentUpdateController {
         return new ResponseForm<>();
     }
 
-    @PostMapping("/{postCommentId}")
-    public ResponseForm createPostCommentLike (@AuthenticationPrincipal AuthorityMemberDTO memberDTO, @PathVariable long postCommentId) {
-        postCommentLikeUpdateService.createPostCommentLike(memberDTO.getProviderId(), postCommentId);
-        return new ResponseForm<>();
+    @PostMapping("/heart/{postCommentId}")
+    public ResponseForm<PostCommentLikeResponse> createPostCommentLike(@AuthenticationPrincipal AuthorityMemberDTO memberDTO, @PathVariable long postCommentId) {
+        return new ResponseForm<>(postCommentLikeUpdateService.createPostCommentLike(memberDTO.getProviderId(), postCommentId));
     }
 }
 

--- a/src/main/java/com/flint/flint/community/dto/response/PostCommentLikeResponse.java
+++ b/src/main/java/com/flint/flint/community/dto/response/PostCommentLikeResponse.java
@@ -1,0 +1,15 @@
+package com.flint.flint.community.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ * @author 정순원
+ * @since 2023-10-16
+ */
+@Data
+@AllArgsConstructor
+public class PostCommentLikeResponse {
+
+    private int postCommentLikeCount;
+}

--- a/src/main/java/com/flint/flint/community/dto/response/PostLikeResponse.java
+++ b/src/main/java/com/flint/flint/community/dto/response/PostLikeResponse.java
@@ -1,0 +1,15 @@
+package com.flint.flint.community.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ * @author 정순원
+ * @since 2023-10-16
+ */
+@Data
+@AllArgsConstructor
+public class PostLikeResponse {
+
+    private int postLikeCount;
+}

--- a/src/main/java/com/flint/flint/community/repository/PostCommentLikeRepository.java
+++ b/src/main/java/com/flint/flint/community/repository/PostCommentLikeRepository.java
@@ -15,4 +15,7 @@ public interface PostCommentLikeRepository extends JpaRepository<PostCommentLike
 
     @Query("SELECT pcl FROM PostCommentLike pcl JOIN pcl.member m WHERE m.providerId = :providerId AND pcl.postComment.id = :postCommentId")
     Optional<PostCommentLike> findByProviderIdAndPostCommentId(@Param("providerId") String providerId, @Param("postCommentId") Long postCommentId);
+
+    @Query("SELECT COUNT(pcl) FROM PostCommentLike pcl WHERE pcl.postComment.id = :postCommentId")
+    int countByPostCommentId(@Param("postCommentId") long postCommentId);
 }

--- a/src/main/java/com/flint/flint/community/repository/PostCommentRepository.java
+++ b/src/main/java/com/flint/flint/community/repository/PostCommentRepository.java
@@ -3,5 +3,9 @@ package com.flint.flint.community.repository;
 import com.flint.flint.community.domain.post.PostComment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+/**
+ * @author 정순원
+ * @since 2023-10-16
+ */
 public interface PostCommentRepository extends JpaRepository<PostComment, Long> {
 }

--- a/src/main/java/com/flint/flint/community/repository/PostLikeRepository.java
+++ b/src/main/java/com/flint/flint/community/repository/PostLikeRepository.java
@@ -1,0 +1,22 @@
+package com.flint.flint.community.repository;
+
+import com.flint.flint.community.domain.post.PostLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+/**
+ * @author 정순원
+ * @since 2023-10-16
+ */
+public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+
+    @Query("SELECT pl FROM PostLike pl JOIN pl.member m WHERE m.providerId = :providerId AND pl.post.id = :postCommentId")
+    Optional<PostLike> findByProviderIdAndPostCommentId(@Param("providerId") String providerId, @Param("postCommentId") Long postCommentId);
+
+    @Query("SELECT COUNT(pl) FROM PostLike pl WHERE pl.post.id = :postId")
+    int countByPostId(@Param("postId") long postId);
+
+}

--- a/src/main/java/com/flint/flint/community/service/PostCommentLikeUpdateService.java
+++ b/src/main/java/com/flint/flint/community/service/PostCommentLikeUpdateService.java
@@ -4,6 +4,7 @@ import com.flint.flint.common.exception.FlintCustomException;
 import com.flint.flint.common.spec.ResultCode;
 import com.flint.flint.community.domain.post.PostComment;
 import com.flint.flint.community.domain.post.PostCommentLike;
+import com.flint.flint.community.dto.response.PostCommentLikeResponse;
 import com.flint.flint.community.repository.PostCommentLikeRepository;
 import com.flint.flint.community.repository.PostCommentRepository;
 import com.flint.flint.member.domain.main.Member;
@@ -26,7 +27,7 @@ public class PostCommentLikeUpdateService {
     private final MemberService memberService;
     private final PostCommentRepository postCommentRepository;
 
-    public void createPostCommentLike(String providerId, long postCommentId) {
+    public PostCommentLikeResponse createPostCommentLike(String providerId, long postCommentId) {
         Optional<PostCommentLike> OptionalCommentLike = postCommentLikeRepository.findByProviderIdAndPostCommentId(providerId, postCommentId);
         if(!OptionalCommentLike.isPresent()) {  //이전에 좋아요를 안했을 때
             Member member = memberService.getMemberByProviderId(providerId);
@@ -38,5 +39,8 @@ public class PostCommentLikeUpdateService {
             postCommentLikeRepository.save(build);
         }
         else postCommentLikeRepository.delete(OptionalCommentLike.get()); // 이전에 좋아요를 했을 때
+
+        int likeCount = postCommentLikeRepository.countByPostCommentId(postCommentId);
+        return new PostCommentLikeResponse(likeCount);
     }
 }

--- a/src/main/java/com/flint/flint/community/service/PostCommentLikeUpdateService.java
+++ b/src/main/java/com/flint/flint/community/service/PostCommentLikeUpdateService.java
@@ -26,10 +26,10 @@ public class PostCommentLikeUpdateService {
     private final MemberService memberService;
     private final PostCommentRepository postCommentRepository;
 
-    public void createPostCommentLike(String provierId, long postCommentId) {
-        Optional<PostCommentLike> OptionalCommentLike = postCommentLikeRepository.findByProviderIdAndPostCommentId(provierId, postCommentId);
+    public void createPostCommentLike(String providerId, long postCommentId) {
+        Optional<PostCommentLike> OptionalCommentLike = postCommentLikeRepository.findByProviderIdAndPostCommentId(providerId, postCommentId);
         if(!OptionalCommentLike.isPresent()) {  //이전에 좋아요를 안했을 때
-            Member member = memberService.getMemberByProviderId(provierId);
+            Member member = memberService.getMemberByProviderId(providerId);
             PostComment postComment = postCommentRepository.findById(postCommentId).orElseThrow(() -> new FlintCustomException(HttpStatus.NOT_FOUND, ResultCode.POST_COMMENT_NOT_FOUND));
             PostCommentLike build = PostCommentLike.builder()
                     .member(member)

--- a/src/main/java/com/flint/flint/community/service/PostLikeUpdateService.java
+++ b/src/main/java/com/flint/flint/community/service/PostLikeUpdateService.java
@@ -1,0 +1,46 @@
+package com.flint.flint.community.service;
+
+import com.flint.flint.common.exception.FlintCustomException;
+import com.flint.flint.common.spec.ResultCode;
+import com.flint.flint.community.domain.post.Post;
+import com.flint.flint.community.domain.post.PostLike;
+import com.flint.flint.community.dto.response.PostLikeResponse;
+import com.flint.flint.community.repository.PostLikeRepository;
+import com.flint.flint.community.repository.PostRepository;
+import com.flint.flint.member.domain.main.Member;
+import com.flint.flint.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+/**
+ * @author 정순원
+ * @since 2023-10-16
+ */
+@Service
+@RequiredArgsConstructor
+public class PostLikeUpdateService {
+
+    private final PostLikeRepository postLikeRepository;
+    private final MemberService memberService;
+    private final PostRepository postRepository;
+
+
+    public PostLikeResponse createPostLike(String providerId, long postId) {
+        Optional<PostLike> OptionalPostLike = postLikeRepository.findByProviderIdAndPostCommentId(providerId, postId);
+        if (!OptionalPostLike.isPresent()) {  //이전에 좋아요를 안했을 때
+            Member member = memberService.getMemberByProviderId(providerId);
+            Post post = postRepository.findById(postId).orElseThrow(() -> new FlintCustomException(HttpStatus.NOT_FOUND, ResultCode.POST_NOT_FOUND));
+            PostLike postLike = PostLike.builder()
+                    .member(member)
+                    .post(post)
+                    .build();
+            postLikeRepository.save(postLike);
+        } else postLikeRepository.delete(OptionalPostLike.get()); // 이전에 좋아요를 했을 때
+
+        int likeCount = postLikeRepository.countByPostId(postId);
+        return new PostLikeResponse(likeCount);
+    }
+}

--- a/src/test/java/com/flint/flint/community/controller/PostCommentUpdateControllerTest.java
+++ b/src/test/java/com/flint/flint/community/controller/PostCommentUpdateControllerTest.java
@@ -1,0 +1,64 @@
+package com.flint.flint.community.controller;
+
+import com.flint.flint.community.domain.post.PostComment;
+import com.flint.flint.community.repository.PostCommentRepository;
+import com.flint.flint.custom_member.WithMockCustomMember;
+import com.flint.flint.member.domain.main.Member;
+import com.flint.flint.member.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class PostCommentUpdateControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    PostCommentUpdateController postCommentUpdateController;
+
+    @Autowired
+    PostCommentRepository postCommentRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+    PostComment postComment;
+
+    @BeforeEach
+    void setUp() {
+        Member member = Member.builder()
+                .name("테스터")
+                .email("test@test.com")
+                .providerName("kakao")
+                .providerId("kakao test")
+                .build();
+
+        memberRepository.save(member);
+
+        postComment = PostComment.builder().contents("테스트 내용입니다.").build();
+        postCommentRepository.save(postComment);
+    }
+
+    @Test
+    @DisplayName("게시글 댓글 좋아요 생성 테스트")
+    @Transactional
+    @WithMockCustomMember(role = "ROLE_AUTHUSER")
+    void test1() throws Exception {
+        //given
+        Long postCommentId = postComment.getId();
+
+        //when,then
+        mockMvc.perform(post("/api/v1/posts/comment/heart/" + postCommentId))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/flint/flint/community/controller/PostCommentUpdateControllerTest.java
+++ b/src/test/java/com/flint/flint/community/controller/PostCommentUpdateControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -59,6 +60,8 @@ class PostCommentUpdateControllerTest {
 
         //when,then
         mockMvc.perform(post("/api/v1/posts/comment/heart/" + postCommentId))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.postCommentLikeCount").value(1));
+
     }
 }


### PR DESCRIPTION
## 관련 이슈
close #88 
## 변경사항
- 게시글 좋아요 API 구현
- 게시글 댓글 좋아요 API 리팩토링
   - 좋아요수 Reponse에 담아주기
- 게시글 댓글 좋아요 통합 테스트 구현
- 
## 개발하면서 발생한 문제점과 해결방안 또는 새롭게 알게된 점
게시글 댓글 좋아요와 비슷해 특별한 점이 없었습니다.

## 당부하고 싶은 말 또는 논의해봐야할 점
x
## 스크린샷
![image](https://github.com/Flint-org/Flint-API-Server/assets/92251131/a4156b1b-a7f3-4a49-a301-ffa11e136a80)

## 기타 및 추후 계획

게시글 검색 API 구현 예정