### PR TITLE
Feat: 특정 게시판 검색 API 구현

### DIFF
--- a/src/main/java/com/flint/flint/community/controller/PostGetController.java
+++ b/src/main/java/com/flint/flint/community/controller/PostGetController.java
@@ -25,8 +25,16 @@ public class PostGetController {
     /**
      * 전체 게시판 검색
      */
-    @GetMapping("/search")
-    public ResponseForm<List<AllPostGetResponse>> getAllPost(@RequestParam String keyword) {
-        return new ResponseForm<>(postGetService.getAllPost(keyword));
+    @GetMapping("/search/all/board")
+    public ResponseForm<List<AllPostGetResponse>> searchInAllBoard(@RequestParam String keyword) {
+        return new ResponseForm<>(postGetService.searchInAllBoard(keyword));
+    }
+
+    /**
+     * 게시판 별 게시판 검색
+     */
+    @GetMapping("/search/specific/board")
+    public ResponseForm<List<AllPostGetResponse>> searchInSpecificBoard(@RequestParam String boardName, @RequestParam String keyword) {
+        return new ResponseForm<>(postGetService.searchInSpecificBoard(boardName, keyword));
     }
 }

--- a/src/main/java/com/flint/flint/community/controller/PostGetController.java
+++ b/src/main/java/com/flint/flint/community/controller/PostGetController.java
@@ -1,0 +1,32 @@
+package com.flint.flint.community.controller;
+
+import com.flint.flint.common.ResponseForm;
+import com.flint.flint.community.dto.response.AllPostGetResponse;
+import com.flint.flint.community.service.PostGetService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * @author 정순원
+ * @since 2023-10-18
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/posts")
+public class PostGetController {
+
+    private final PostGetService postGetService;
+
+    /**
+     * 전체 게시판 검색
+     */
+    @GetMapping("/search")
+    public ResponseForm<List<AllPostGetResponse>> getAllPost(@RequestParam String keyword) {
+        return new ResponseForm<>(postGetService.getAllPost(keyword));
+    }
+}

--- a/src/main/java/com/flint/flint/community/domain/post/Post.java
+++ b/src/main/java/com/flint/flint/community/domain/post/Post.java
@@ -31,7 +31,7 @@ public class Post extends BaseTimeEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "BOARD_ID")
     private Board board;
 

--- a/src/main/java/com/flint/flint/community/dto/response/AllPostGetResponse.java
+++ b/src/main/java/com/flint/flint/community/dto/response/AllPostGetResponse.java
@@ -1,0 +1,12 @@
+package com.flint.flint.community.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class AllPostGetResponse {
+
+    private String title;
+    private String imageURL;
+}

--- a/src/main/java/com/flint/flint/community/dto/response/AllPostGetResponse.java
+++ b/src/main/java/com/flint/flint/community/dto/response/AllPostGetResponse.java
@@ -7,6 +7,7 @@ import lombok.Data;
 @AllArgsConstructor
 public class AllPostGetResponse {
 
+    private long postId;
     private String title;
     private String imageURL;
 }

--- a/src/main/java/com/flint/flint/community/repository/BoardRepository.java
+++ b/src/main/java/com/flint/flint/community/repository/BoardRepository.java
@@ -12,4 +12,6 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
     List<Board> findBoardsByBoardType(BoardType type);
 
     Optional<Board> findBoardByGeneralBoardName(String name);
+
+    Optional<Board> findByGeneralBoardName(String boardName);
 }

--- a/src/main/java/com/flint/flint/community/repository/PostRepository.java
+++ b/src/main/java/com/flint/flint/community/repository/PostRepository.java
@@ -1,5 +1,6 @@
 package com.flint.flint.community.repository;
 
+import com.flint.flint.community.domain.board.Board;
 import com.flint.flint.community.domain.post.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -10,9 +11,17 @@ import java.util.List;
 public interface PostRepository extends JpaRepository<Post, Long> {
 
     /**
+     * 전체게시판에서
      * 제목이나 내용에 키워드가 포함된 글 최신순으로 가져오기
      */
     @Query("SELECT p FROM Post p WHERE p.title LIKE %:keyword% OR p.contents LIKE %:keyword% ORDER BY p.createdAt DESC")
     List<Post> findByTitleContainingOrContentsContainingOrderByCreatedAtDesc(@Param("keyword") String keyword);
+
+    /**
+     * 특정 게시판에서
+     * 제목이나 내용에 키워드가 포함된 글 최신순으로 가져오기
+     */
+    @Query("SELECT p FROM Post p WHERE p.title LIKE %:keyword% OR p.contents LIKE %:keyword% And p.board.id = :boardId ORDER BY p.createdAt DESC")
+    List<Post> findByTitleContainingOrContentsContainingAndBoardOrderByCreatedAtDesc(@Param("boardId") long boardId, @Param("keyword") String keyword);
 
 }

--- a/src/main/java/com/flint/flint/community/repository/PostRepository.java
+++ b/src/main/java/com/flint/flint/community/repository/PostRepository.java
@@ -1,6 +1,5 @@
 package com.flint.flint.community.repository;
 
-import com.flint.flint.community.domain.board.Board;
 import com.flint.flint.community.domain.post.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/com/flint/flint/community/repository/PostRepository.java
+++ b/src/main/java/com/flint/flint/community/repository/PostRepository.java
@@ -2,6 +2,17 @@ package com.flint.flint.community.repository;
 
 import com.flint.flint.community.domain.post.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    /**
+     * 제목이나 내용에 키워드가 포함된 글 최신순으로 가져오기
+     */
+    @Query("SELECT p FROM Post p WHERE p.title LIKE %:keyword% OR p.contents LIKE %:keyword% ORDER BY p.createdAt DESC")
+    List<Post> findByTitleContainingOrContentsContainingOrderByCreatedAtDesc(@Param("keyword") String keyword);
+
 }

--- a/src/main/java/com/flint/flint/community/service/PostGetService.java
+++ b/src/main/java/com/flint/flint/community/service/PostGetService.java
@@ -1,10 +1,16 @@
 package com.flint.flint.community.service;
 
+import com.flint.flint.common.exception.FlintCustomException;
+import com.flint.flint.common.spec.ResultCode;
+import com.flint.flint.community.domain.board.Board;
 import com.flint.flint.community.domain.post.Post;
 import com.flint.flint.community.dto.response.AllPostGetResponse;
+import com.flint.flint.community.repository.BoardRepository;
 import com.flint.flint.community.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -18,14 +24,26 @@ public class PostGetService {
 
     private final PostRepository postRepository;
 
-    public List<AllPostGetResponse> getAllPost(String keyword) {
+    private final BoardRepository boardRepository;
+
+    @Transactional(readOnly = true)
+    public List<AllPostGetResponse> searchInAllBoard(String keyword) {
         List<Post> postList = postRepository.findByTitleContainingOrContentsContainingOrderByCreatedAtDesc(keyword);
 
         return postList.stream()
-                .map(post -> new AllPostGetResponse(post.getTitle(), getFirstImageUrl(post)))
+                .map(post -> new AllPostGetResponse(post.getId(), post.getTitle(), getFirstImageUrl(post)))
                 .toList();
     }
 
+    @Transactional(readOnly = true)
+    public List<AllPostGetResponse> searchInSpecificBoard(String boardName, String keyword) {
+        Board board = boardRepository.findByGeneralBoardName(boardName).orElseThrow(() -> new FlintCustomException(HttpStatus.HTTP_VERSION_NOT_SUPPORTED, ResultCode.BOARD_NOT_FOUND));
+        List<Post> postList = postRepository.findByTitleContainingOrContentsContainingAndBoardOrderByCreatedAtDesc(board.getId(), keyword);
+
+        return postList.stream()
+                .map(post -> new AllPostGetResponse(post.getId(), post.getTitle(), getFirstImageUrl(post)))
+                .toList();
+    }
     // Post에서 첫 번째 이미지 URL을 가져오는 메서드
     private String getFirstImageUrl(Post post) {
         if (post.getPostImages() != null && !post.getPostImages().isEmpty()) {

--- a/src/main/java/com/flint/flint/community/service/PostGetService.java
+++ b/src/main/java/com/flint/flint/community/service/PostGetService.java
@@ -1,0 +1,33 @@
+package com.flint.flint.community.service;
+
+import com.flint.flint.community.domain.post.Post;
+import com.flint.flint.community.dto.response.AllPostGetResponse;
+import com.flint.flint.community.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PostGetService {
+
+    private final PostRepository postRepository;
+
+    public List<AllPostGetResponse> getAllPost(String keyword) {
+        List<Post> postList = postRepository.findByTitleContainingOrContentsContainingOrderByCreatedAtDesc(keyword);
+
+        return postList.stream()
+                .map(post -> new AllPostGetResponse(post.getTitle(), getFirstImageUrl(post)))
+                .toList();
+    }
+
+    // Post에서 첫 번째 이미지 URL을 가져오는 메서드
+    private String getFirstImageUrl(Post post) {
+        if (post.getPostImages() != null && !post.getPostImages().isEmpty()) {
+            return post.getPostImages().get(0).getImgUrl();
+        } else {
+            return ""; //TODO 기본 이미지 URL을 반환
+        }
+    }
+}

--- a/src/main/java/com/flint/flint/community/service/PostGetService.java
+++ b/src/main/java/com/flint/flint/community/service/PostGetService.java
@@ -8,6 +8,10 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+/**
+ * @author 정순원
+ * @since 2023-10-19
+ */
 @Service
 @RequiredArgsConstructor
 public class PostGetService {

--- a/src/main/java/com/flint/flint/member/domain/main/Member.java
+++ b/src/main/java/com/flint/flint/member/domain/main/Member.java
@@ -11,12 +11,10 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
-
-import java.time.LocalDate;
 
 /**
  * 첫 생성시 별점 0점, 인증 안한 유저로 초기화
+ *
  * @Author 정순원
  * @Since 2023-08-07
  */
@@ -40,8 +38,8 @@ public class Member extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private Gender gender;
 
-    @DateTimeFormat(pattern = "YYYY")
-    private LocalDate birthday;
+    @Column(length = 4)
+    private String birthday;
 
     @Max(5)
     @Min(0)
@@ -61,7 +59,7 @@ public class Member extends BaseTimeEntity {
     public Member(String email,
                   String name,
                   Gender gender,
-                  LocalDate birthday,
+                  String birthday,
                   Authority authority,
                   String providerName,
                   String providerId) {

--- a/src/main/java/com/flint/flint/security/auth/AuthenticationController.java
+++ b/src/main/java/com/flint/flint/security/auth/AuthenticationController.java
@@ -3,7 +3,7 @@ package com.flint.flint.security.auth;
 import com.flint.flint.common.ResponseForm;
 import com.flint.flint.security.auth.dto.AuthenticationResponse;
 import com.flint.flint.security.auth.dto.RegisterRequest;
-import com.flint.flint.security.oauth.dto.OAuth2AccessToken;
+import com.flint.flint.security.oauth.dto.AuthorizionRequestHeader;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
@@ -24,15 +24,15 @@ public class AuthenticationController {
     //테스트용
 
     @PostMapping("/register")
-    public ResponseForm<AuthenticationResponse> register(@Valid @RequestBody RegisterRequest registerRequest, @RequestHeader(HttpHeaders.AUTHORIZATION) OAuth2AccessToken oAuth2AccessToken) {
-        AuthenticationResponse authenticationResponse = authenticationService.register(registerRequest, oAuth2AccessToken);
+    public ResponseForm<AuthenticationResponse> register(@Valid @RequestBody RegisterRequest registerRequest, @RequestHeader(HttpHeaders.AUTHORIZATION) AuthorizionRequestHeader authorizionRequestHeader) {
+        AuthenticationResponse authenticationResponse = authenticationService.register(registerRequest, authorizionRequestHeader);
         return new ResponseForm<>(authenticationResponse);
 
     }
 
     @PostMapping("/login/{providerName}")
-    public ResponseForm<AuthenticationResponse> login(@PathVariable String providerName, @RequestHeader(HttpHeaders.AUTHORIZATION) OAuth2AccessToken oAuth2AccessToken) {
-        AuthenticationResponse authenticationResponse = authenticationService.login(providerName, oAuth2AccessToken);
+    public ResponseForm<AuthenticationResponse> login(@PathVariable String providerName, @RequestHeader(HttpHeaders.AUTHORIZATION) AuthorizionRequestHeader authorizionRequestHeader) {
+        AuthenticationResponse authenticationResponse = authenticationService.login(providerName, authorizionRequestHeader);
         return new ResponseForm<>(authenticationResponse);
     }
 

--- a/src/main/java/com/flint/flint/security/auth/AuthenticationService.java
+++ b/src/main/java/com/flint/flint/security/auth/AuthenticationService.java
@@ -11,7 +11,7 @@ import com.flint.flint.security.auth.dto.AuthenticationResponse;
 import com.flint.flint.security.auth.dto.ClaimsDTO;
 import com.flint.flint.security.auth.dto.RegisterRequest;
 import com.flint.flint.security.oauth.dto.OAuth2UserAttribute;
-import com.flint.flint.security.oauth.dto.OAuth2AccessToken;
+import com.flint.flint.security.oauth.dto.AuthorizionRequestHeader;
 import com.flint.flint.security.oauth.dto.OAuth2UserAttributeFactory;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -41,11 +41,12 @@ public class AuthenticationService {
      * member 저장, 수신동의 저장, 엑세스,리프레쉬토큰 생성, redis에 리프레쉬 토큰 저장
      */
     @Transactional
-    public AuthenticationResponse register(RegisterRequest registerRequest, OAuth2AccessToken oAuth2AccessToken) {
+    public AuthenticationResponse register(RegisterRequest registerRequest, AuthorizionRequestHeader authorizionRequestHeader) {
         //카카오인지 네이버인지 선택
         OAuth2UserAttribute oAuth2UserAttribute = OAuth2UserAttributeFactory.of(registerRequest.getProviderName());
+        String oauth2AccessToekn = authorizionRequestHeader.getAccessToken().replace("Bearer ", "");
         //정보 추출
-        oAuth2UserAttribute.UserAttributesByOAuthToken(oAuth2AccessToken);
+        oAuth2UserAttribute.setUserAttributesByOauthToken(oauth2AccessToekn);
         Member member = oAuth2UserAttribute.toEntity();
         Policy policy = Policy.builder().
                 member(member).
@@ -62,9 +63,11 @@ public class AuthenticationService {
      * 엑세스,리프레쉬토큰 생성, redis에 리프레쉬 토큰 저장
      */
     @Transactional
-    public AuthenticationResponse login(String providerName, OAuth2AccessToken oAuth2AccessToken) {
+    public AuthenticationResponse login(String providerName, AuthorizionRequestHeader authorizionRequestHeader) {
         OAuth2UserAttribute oAuth2UserAttribute = OAuth2UserAttributeFactory.of(providerName);
-        oAuth2UserAttribute.UserAttributesByOAuthToken(oAuth2AccessToken);
+        String oauth2AccessToekn = authorizionRequestHeader.getAccessToken().replace("Bearer", "");
+        //정보 추출
+        oAuth2UserAttribute.setUserAttributesByOauthToken(oauth2AccessToekn);
         String providerId = oAuth2UserAttribute.getProviderId();
         Member member = memberRepository.findByProviderId(providerId).orElseThrow();
         return generateToken(member);

--- a/src/main/java/com/flint/flint/security/auth/dto/RegisterRequest.java
+++ b/src/main/java/com/flint/flint/security/auth/dto/RegisterRequest.java
@@ -1,15 +1,16 @@
 package com.flint.flint.security.auth.dto;
 
 import jakarta.validation.constraints.NotBlank;
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 
 /**
  * @Author 정순원
  * @Since 2023-08-23
  */
 @Getter
-@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class RegisterRequest {
 
     @NotBlank

--- a/src/main/java/com/flint/flint/security/oauth/dto/AuthorizionRequestHeader.java
+++ b/src/main/java/com/flint/flint/security/oauth/dto/AuthorizionRequestHeader.java
@@ -12,7 +12,7 @@ import lombok.Getter;
 @Getter
 @Data
 @AllArgsConstructor
-public class OAuth2AccessToken {
+public class AuthorizionRequestHeader {
 
     private String accessToken;
 

--- a/src/main/java/com/flint/flint/security/oauth/dto/KakaoOAuth2UserAttribute.java
+++ b/src/main/java/com/flint/flint/security/oauth/dto/KakaoOAuth2UserAttribute.java
@@ -1,6 +1,7 @@
 package com.flint.flint.security.oauth.dto;
 
 import com.flint.flint.member.domain.main.Member;
+import com.flint.flint.member.spec.Authority;
 import com.flint.flint.member.spec.Gender;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -8,7 +9,6 @@ import lombok.NoArgsConstructor;
 import net.minidev.json.JSONObject;
 import org.springframework.web.reactive.function.client.WebClient;
 
-import java.time.LocalDate;
 import java.util.Map;
 
 /**
@@ -29,13 +29,15 @@ public class KakaoOAuth2UserAttribute extends OAuth2UserAttribute {
 
     @Override
     public Member toEntity() {
+
         return Member.builder()
                 .providerName(KAKAO_PROVIDER_ID)
                 .providerId(KAKAO_PROVIDER_ID+" "+getProviderId())//띄어쓰기 포함
                 .email(getEmail())
                 .name(getName())
                 .gender(Gender.valueOf(getGender().toUpperCase())) //대소문자 구별하니 바꿔줘야 함
-                .birthday(LocalDate.parse(getBirthday()))
+                .authority(Authority.AUTHUSER)
+                .birthday(getBirthday())
                 .build();
     }
 
@@ -64,13 +66,13 @@ public class KakaoOAuth2UserAttribute extends OAuth2UserAttribute {
     }
 
     @Override
-    public void UserAttributesByOAuthToken(OAuth2AccessToken oauth2AccessToken) {
+    public void setUserAttributesByOauthToken(String authorizionRequestHeader) {
 
 
         JSONObject response = WebClient.create()
                 .get()
                 .uri("https://kapi.kakao.com/v2/user/me")
-                .headers(httpHeaders -> httpHeaders.setBearerAuth(oauth2AccessToken.getAccessToken()))
+                .headers(httpHeaders -> httpHeaders.setBearerAuth(authorizionRequestHeader))
                 .retrieve()
                 .bodyToMono(JSONObject.class)
                 .block();

--- a/src/main/java/com/flint/flint/security/oauth/dto/NaverOAuth2UserAttribute.java
+++ b/src/main/java/com/flint/flint/security/oauth/dto/NaverOAuth2UserAttribute.java
@@ -1,6 +1,7 @@
 package com.flint.flint.security.oauth.dto;
 
 import com.flint.flint.member.domain.main.Member;
+import com.flint.flint.member.spec.Authority;
 import com.flint.flint.member.spec.Gender;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -8,7 +9,6 @@ import lombok.NoArgsConstructor;
 import net.minidev.json.JSONObject;
 import org.springframework.web.reactive.function.client.WebClient;
 
-import java.time.LocalDate;
 import java.util.Map;
 
 /**
@@ -30,11 +30,12 @@ public class NaverOAuth2UserAttribute extends OAuth2UserAttribute {
     public Member toEntity() {
         return Member.builder()
                 .providerName(NAVER_PROVIDER_ID)
-                .providerId(NAVER_PROVIDER_ID+" "+getProviderId())
+                .providerId(NAVER_PROVIDER_ID + " " + getProviderId())
                 .email(getEmail())
                 .name(getName())
                 .gender(Gender.valueOf(getGender().toUpperCase())) //대소문자 구별하니 바꿔줘야 함
-                .birthday(LocalDate.parse(getBirthday()))
+                .authority(Authority.AUTHUSER)
+                .birthday(getBirthday())
                 .build();
     }
 
@@ -64,18 +65,16 @@ public class NaverOAuth2UserAttribute extends OAuth2UserAttribute {
     }
 
     @Override
-    public void UserAttributesByOAuthToken(OAuth2AccessToken oauth2AccessToken) {
+    public void setUserAttributesByOauthToken(String authorizionRequestHeader) {
 
 
-        JSONObject response = WebClient.create()
+        JSONObject naverResponse = WebClient.create()
                 .get()
                 .uri("https://openapi.naver.com/v1/nid/me")
-                .headers(httpHeaders -> httpHeaders.setBearerAuth(oauth2AccessToken.getAccessToken()))
+                .headers(httpHeaders -> httpHeaders.setBearerAuth(authorizionRequestHeader))
                 .retrieve()
                 .bodyToMono(JSONObject.class)
                 .block();
-
-        Map<String, Object> kakaoAccount = (Map<String, Object>)response.get("response");
-
+        this.response = (Map<String, Object>)naverResponse.get("response");
     }
 }

--- a/src/main/java/com/flint/flint/security/oauth/dto/OAuth2UserAttribute.java
+++ b/src/main/java/com/flint/flint/security/oauth/dto/OAuth2UserAttribute.java
@@ -4,7 +4,6 @@ import com.flint.flint.member.domain.main.Member;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -32,6 +31,6 @@ public abstract class OAuth2UserAttribute {
 
     public abstract Member toEntity();
 
-    public abstract void UserAttributesByOAuthToken(OAuth2AccessToken OAuth2AccessToken);
+    public abstract void setUserAttributesByOauthToken(String authorizionRequestHeader);
 
 }

--- a/src/test/java/com/flint/flint/community/controller/PostGetControllerTest.java
+++ b/src/test/java/com/flint/flint/community/controller/PostGetControllerTest.java
@@ -115,7 +115,7 @@ class PostGetControllerTest {
 
     @Test
     @Transactional
-    @DisplayName("키워드 포함한 게시글 조회")
+    @DisplayName("특정 게시판에서 키워드 포함한 게시글 조회")
     @WithMockCustomMember(role = "ROLE_UNAUTHUSER")
     void test2() throws Exception {
 

--- a/src/test/java/com/flint/flint/community/controller/PostGetControllerTest.java
+++ b/src/test/java/com/flint/flint/community/controller/PostGetControllerTest.java
@@ -1,0 +1,95 @@
+package com.flint.flint.community.controller;
+
+import com.flint.flint.community.domain.post.Post;
+import com.flint.flint.community.domain.post.PostImage;
+import com.flint.flint.community.repository.PostRepository;
+import com.flint.flint.custom_member.WithMockCustomMember;
+import jakarta.persistence.EntityManagerFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class PostGetControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    PostRepository postRepository;
+
+    @Autowired
+    EntityManagerFactory emf;
+
+    @BeforeEach
+    void setUp() {
+        Post post1 = Post.builder()
+                .title("제목1")
+                .contents("내용1")
+                .build();
+
+        Post post2 = Post.builder()
+                .title("제목2")
+                .contents("내용2")
+                .build();
+
+        Post post3 = Post.builder()
+                .title("제목3")
+                .contents("내용3")
+                .build();
+
+        PostImage postImage1 = PostImage.builder()
+                .post(post1)
+                .imgUrl("url1")
+                .build();
+
+        PostImage postImage2 = PostImage.builder()
+                .post(post1)
+                .imgUrl("url2")
+                .build();
+
+        PostImage postImage3 = PostImage.builder()
+                .post(post2)
+                .imgUrl("url3")
+                .build();
+
+        post1.addImageUrl(postImage1);
+        post1.addImageUrl(postImage2);
+        post2.addImageUrl(postImage3);
+
+        //post1이 url1,url2를 가지고 post2가 url3을 가지고 post1을 이미지 없음
+        postRepository.save(post1);
+        postRepository.save(post2);
+        postRepository.save(post3);
+
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("키워드 포함한 게시글 조회")
+    @WithMockCustomMember(role = "ROLE_UNAUTHUSER")
+    void test1() throws Exception {
+
+        mockMvc.perform(get("/api/v1/posts/search")
+                        .param("keyword", "내용"))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.content().contentType("application/json"))
+                .andExpect(jsonPath("$.data[0].title").value("제목3"))
+                .andExpect(jsonPath("$.data[0].imageURL").value(""))
+                .andExpect(jsonPath("$.data[1].title").value("제목2"))
+                .andExpect(jsonPath("$.data[1].imageURL").value("url3"))
+                .andExpect(jsonPath("$.data[2].title").value("제목1"))
+                .andExpect(jsonPath("$.data[2].imageURL").value("url1"));
+    }
+}


### PR DESCRIPTION
## 관련 이슈
close #94 
## 변경사항

- 특정 게시판 검색 API 구현 
  - 전체 게시판 검색과 로직이 비슷하여 쉽게 구현하였습니다.
- 회원가입/로그인 리팩토링
  -  기존에 Oauth2에게 요청(사용자 정보 빼오기)을 보낼 때 "Bearer "이 떼어지지 않은 채 요청이 되어 401에러가 떴습니다. 이를 수정하였습니다. 
  - 적절한 naming으로 변경
  - 탄생연도(ex "2000")를 Localdate로 저장할필요가 없을 것 같아 String으로 변수타입을 변경하였습니다.
  
## 개발하면서 발생한 문제점과 해결방안 또는 새롭게 알게된 점
## 당부하고 싶은 말 또는 논의해봐야할 점
## 스크린샷
![image](https://github.com/Flint-org/Flint-API-Server/assets/92251131/f639695c-a91c-4a32-b62b-ffdea1fea230)

## 기타 및 추후 계획

- 수, 목 시험기간이라 당분간은 학교 공부를 해야 할 것 같습니다.
