### PR TITLE
fix: 유효하지 않은 대분류로 전공 게시판 조회 시 잘못된 결과 반환 오류 수정 

### DIFF
--- a/src/main/java/com/flint/flint/common/spec/ResultCode.java
+++ b/src/main/java/com/flint/flint/common/spec/ResultCode.java
@@ -34,9 +34,11 @@ public enum ResultCode {
     EXCESS_POST_IMAGE_LIMIT("F402", "게시글의 최대 이미지 개수는 20장입니다."),
     ALREADY_BOOKMARKED_BOARD("F403", "이미 즐겨찾기된 게시판입니다."),
     UNKNOWN_BOOKMARK_BOARD("F404", "해당 게시판은 즐겨찾기가 되어있지 않습니다."),
-    POST_NOT_FOUND("405", "존재하지 않는 게시글입니다."),
-    POST_COMMENT_NOT_FOUND("406", "존재하지 않는 게시글 댓글입니다."),
-    POST_COMMENT_NOT_WRITER("407", "글쓴이가 아닙니다."),
+    POST_NOT_FOUND("F405", "존재하지 않는 게시글입니다."),
+    POST_COMMENT_NOT_FOUND("F406", "존재하지 않는 게시글 댓글입니다."),
+    POST_COMMENT_NOT_WRITER("F407", "글쓴이가 아닙니다."),
+    MAJOR_UPPER_BOARD_NOT_FOUND("F400", "존재하지 않는 전공 대분류입니다."),
+
 
     // F5xx: 모임 예외
     CLUB_NOT_FOUND_ERROR("F500", "모임을 찾을 수 없습니다."),
@@ -69,7 +71,7 @@ public enum ResultCode {
 
     // F9xx: 명함 예외
     IDCARD_NOT_FOUND("F900", "명함을 찾을 수 없습니다."),
-    IDCARDBOX_NOT_FOUND("F901","유저가 이 명함을 가지고 있지 않습니다.");
+    IDCARDBOX_NOT_FOUND("F901", "유저가 이 명함을 가지고 있지 않습니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/flint/flint/common/spec/ResultCode.java
+++ b/src/main/java/com/flint/flint/common/spec/ResultCode.java
@@ -37,7 +37,7 @@ public enum ResultCode {
     POST_NOT_FOUND("F405", "존재하지 않는 게시글입니다."),
     POST_COMMENT_NOT_FOUND("F406", "존재하지 않는 게시글 댓글입니다."),
     POST_COMMENT_NOT_WRITER("F407", "글쓴이가 아닙니다."),
-    MAJOR_UPPER_BOARD_NOT_FOUND("F400", "존재하지 않는 전공 대분류입니다."),
+    MAJOR_UPPER_BOARD_NOT_FOUND("F408", "존재하지 않는 전공 대분류입니다."),
 
 
     // F5xx: 모임 예외

--- a/src/main/java/com/flint/flint/community/repository/MajorBoardRepository.java
+++ b/src/main/java/com/flint/flint/community/repository/MajorBoardRepository.java
@@ -13,4 +13,6 @@ public interface MajorBoardRepository extends JpaRepository<MajorBoard, Long> {
     List<MajorBoard> findMajorBoardsByUpperMajorBoard(MajorBoard upperMajor);
 
     Optional<MajorBoard> findMajorBoardByName(String majorName);
+
+    Optional<MajorBoard> findMajorBoardByUpperMajorBoardIsNullAndId(Long upperMajorId);
 }

--- a/src/main/java/com/flint/flint/community/service/BoardService.java
+++ b/src/main/java/com/flint/flint/community/service/BoardService.java
@@ -103,9 +103,9 @@ public class BoardService {
      */
     @Transactional(readOnly = true)
     public UpperMajorInfoResponse getLowerMajorListByUpperMajor(Long upperMajorId) {
-        // 해당 전공 게시판이 존재하는지 검증
-        MajorBoard upperMajor = majorBoardRepository.findById(upperMajorId)
-                .orElseThrow(() -> new FlintCustomException(HttpStatus.NOT_FOUND, MAJOR_BOARD_NOT_FOUND));
+        // 주어진 대분류에 해당하는 전공 게시판이 존재하는지 검증
+        MajorBoard upperMajor = majorBoardRepository.findMajorBoardByUpperMajorBoardIsNullAndId(upperMajorId)
+                .orElseThrow(() -> new FlintCustomException(HttpStatus.NOT_FOUND, MAJOR_UPPER_BOARD_NOT_FOUND));
 
         List<MajorBoard> lowerMajors = majorBoardRepository.findMajorBoardsByUpperMajorBoard(upperMajor);
 

--- a/src/test/java/com/flint/flint/community/service/BoardServiceTest.java
+++ b/src/test/java/com/flint/flint/community/service/BoardServiceTest.java
@@ -254,7 +254,7 @@ class BoardServiceTest {
         // when, then
         assertThatThrownBy(() -> boardService.getLowerMajorListByUpperMajor(upperMajorID))
                 .isInstanceOf(FlintCustomException.class)
-                .hasMessage(ResultCode.MAJOR_BOARD_NOT_FOUND.getMessage());
+                .hasMessage(ResultCode.MAJOR_UPPER_BOARD_NOT_FOUND.getMessage());
     }
 
     @DisplayName("유저가 게시판을 즐겨찾기에 등록하면, 성공적으로 처리된다.")

--- a/src/test/java/com/flint/flint/community/service/BoardServiceTest.java
+++ b/src/test/java/com/flint/flint/community/service/BoardServiceTest.java
@@ -354,4 +354,16 @@ class BoardServiceTest {
         // then
         assertThat(bookmarkRepository.findBoardBookmarkByMemberAndBoard(member, board).isEmpty()).isTrue();
     }
+
+    @DisplayName("유효하지 않은 전공 게시판 대분류 ID로 조회 시 예외 발생 테스트")
+    @Test
+    void getMajorBoardByInvalidUpperId() {
+        // given
+        Long upperMajorId = 1000L;
+
+        // when, then
+        assertThatThrownBy(() -> boardService.getLowerMajorListByUpperMajor(upperMajorId))
+                .isInstanceOf(FlintCustomException.class)
+                .hasMessage(ResultCode.MAJOR_UPPER_BOARD_NOT_FOUND.getMessage());
+    }
 }


### PR DESCRIPTION
## 관련 이슈
close #96 
## 변경사항
- 클라이언트 테스트 중 특정 대분류로 전공 게시판을 검색하는 API에서 DB 상에 없는 전공 게시판 ID로 검색했을 때, 대분류가 결과로 나오는, 게시판 ID로 검색한 현상이 있었습니다. (요청은 성공하지만 데이터 자체는 이상하게 주는 현상)
- 클라이언트 상에서 API를 사용하는데 큰 문제는 없지만 엄연한 오류이므로 수정했습니다.
- path variable로 받은 대분류 ID로 전공 게시판 엔티티를 검색할 때 조건을 추가하였습니다.
  - upper major id가 null인 전공 게시판 데이터(= 대분류 조회) 
## 개발하면서 발생한 문제점과 해결방안 또는 새롭게 알게된 점
x
## 당부하고 싶은 말 또는 논의해봐야할 점
x
## 스크린샷
`/api/v1/boards/major/uppers/1000` 으로 요청 시 결과
![image](https://github.com/Flint-org/Flint-API-Server/assets/54919474/72941418-c230-48f1-98a5-f925dc71c8c1)

![image](https://github.com/Flint-org/Flint-API-Server/assets/54919474/d46f1c65-8465-43c6-8a0a-b96a9bc88d96)
![image](https://github.com/Flint-org/Flint-API-Server/assets/54919474/c16a5e25-4d04-481a-8b8d-c82357afcd09)


## 기타 및 추후 계획

