### PR TITLE
Feat 게시글 스크랩 생성/취소 API 

### DIFF
--- a/src/main/java/com/flint/flint/common/spec/ResultCode.java
+++ b/src/main/java/com/flint/flint/common/spec/ResultCode.java
@@ -37,6 +37,7 @@ public enum ResultCode {
     POST_NOT_FOUND("405", "존재하지 않는 게시글입니다."),
     POST_COMMENT_NOT_FOUND("406", "존재하지 않는 게시글 댓글입니다."),
     POST_COMMENT_NOT_WRITER("407", "글쓴이가 아닙니다."),
+    POST_SCRAP_NOT_FOUND("408", "존재하지 않는 게시물 스크랩입니다."),
 
     // F5xx: 모임 예외
     CLUB_NOT_FOUND_ERROR("F500", "모임을 찾을 수 없습니다."),

--- a/src/main/java/com/flint/flint/community/controller/PostApiController.java
+++ b/src/main/java/com/flint/flint/community/controller/PostApiController.java
@@ -23,7 +23,7 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/posts")
-@PreAuthorize("hasRole('ROLE_AUTHUSER')")
+@PreAuthorize("isAuthenticated()")
 public class PostApiController {
 
     private final PostService postService;

--- a/src/main/java/com/flint/flint/community/controller/PostApiController.java
+++ b/src/main/java/com/flint/flint/community/controller/PostApiController.java
@@ -40,7 +40,7 @@ public class PostApiController {
     }
 
     /**
-     * 좋아요 생성 취소 API
+     * 좋아요 생성 취소
      */
     @PostMapping("/like/{postId}")
     public ResponseForm<PostLikeResponse> createPostLike(@AuthenticationPrincipal AuthorityMemberDTO memberDTO, @PathVariable long postId) {
@@ -48,11 +48,20 @@ public class PostApiController {
     }
 
     /**
-     * 스크랩 생성 취소 API
+     * 스크랩 생성
      */
     @PostMapping("/scrap/{postId}")
-    public ResponseForm touchPostScrap(@AuthenticationPrincipal AuthorityMemberDTO memberDTO, @PathVariable long postId) {
-        postScrapUpdateService.touchPostScrap(memberDTO.getProviderId(), postId);
+    public ResponseForm createScrap (@AuthenticationPrincipal AuthorityMemberDTO memberDTO, @PathVariable long postId) {
+        postScrapUpdateService.createScrap(memberDTO.getProviderId(), postId);
+        return new ResponseForm<>();
+    }
+
+    /**
+     * 스크랩 삭제
+     */
+    @DeleteMapping("/scrap/{postId}")
+    public ResponseForm deleteScrap (@AuthenticationPrincipal AuthorityMemberDTO memberDTO, @PathVariable long postId) {
+        postScrapUpdateService.deleteScrap(memberDTO.getProviderId(), postId);
         return new ResponseForm<>();
     }
 }

--- a/src/main/java/com/flint/flint/community/controller/PostApiController.java
+++ b/src/main/java/com/flint/flint/community/controller/PostApiController.java
@@ -5,6 +5,7 @@ import com.flint.flint.community.dto.request.PostRequest;
 import com.flint.flint.community.dto.response.PostLikeResponse;
 import com.flint.flint.community.dto.response.PostPreSignedUrlResponse;
 import com.flint.flint.community.service.PostLikeUpdateService;
+import com.flint.flint.community.service.PostScrapUpdateService;
 import com.flint.flint.community.service.PostService;
 import com.flint.flint.security.auth.dto.AuthorityMemberDTO;
 import jakarta.validation.Valid;
@@ -22,12 +23,14 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/posts")
+@PreAuthorize("hasRole('ROLE_AUTHUSER')")
 public class PostApiController {
+
     private final PostService postService;
     private final PostLikeUpdateService postLikeUpdateService;
+    private final PostScrapUpdateService postScrapUpdateService;
 
 
-    @PreAuthorize("hasRole('ROLE_AUTHUSER')")
     @PostMapping("")
     public ResponseForm<List<PostPreSignedUrlResponse>> createPost(
             @AuthenticationPrincipal AuthorityMemberDTO memberDTO,
@@ -36,8 +39,20 @@ public class PostApiController {
         return new ResponseForm<>(postService.createPost(memberDTO.getProviderId(), postRequest));
     }
 
-    @PostMapping("/heart/{postId}")
+    /**
+     * 좋아요 생성 취소 API
+     */
+    @PostMapping("/like/{postId}")
     public ResponseForm<PostLikeResponse> createPostLike(@AuthenticationPrincipal AuthorityMemberDTO memberDTO, @PathVariable long postId) {
         return new ResponseForm<>(postLikeUpdateService.createPostLike(memberDTO.getProviderId(), postId));
+    }
+
+    /**
+     * 스크랩 생성 취소 API
+     */
+    @PostMapping("/scrap/{postId}")
+    public ResponseForm touchPostScrap(@AuthenticationPrincipal AuthorityMemberDTO memberDTO, @PathVariable long postId) {
+        postScrapUpdateService.touchPostScrap(memberDTO.getProviderId(), postId);
+        return new ResponseForm<>();
     }
 }

--- a/src/main/java/com/flint/flint/community/controller/PostCommentUpdateController.java
+++ b/src/main/java/com/flint/flint/community/controller/PostCommentUpdateController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/posts/comment")
-@PreAuthorize("hasRole('ROLE_AUTHUSER')")
+@PreAuthorize("isAuthenticated()")
 public class PostCommentUpdateController {
 
     private final PostCommentUpdateService postCommentUpdateService;

--- a/src/main/java/com/flint/flint/community/repository/PostScrapRepository.java
+++ b/src/main/java/com/flint/flint/community/repository/PostScrapRepository.java
@@ -1,0 +1,15 @@
+package com.flint.flint.community.repository;
+
+import com.flint.flint.community.domain.post.PostScrap;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface PostScrapRepository extends JpaRepository<PostScrap, Long> {
+
+    @Query("SELECT ps FROM PostScrap ps JOIN ps.member m WHERE m.providerId = :providerId AND ps.post.id = :postId")
+    Optional<PostScrap> findByProviderIdAndPostId(@Param("providerId") String providerId, @Param("postId") Long postId);
+
+}

--- a/src/main/java/com/flint/flint/community/service/PostScrapUpdateService.java
+++ b/src/main/java/com/flint/flint/community/service/PostScrapUpdateService.java
@@ -11,6 +11,7 @@ import com.flint.flint.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -22,6 +23,7 @@ public class PostScrapUpdateService {
     private final MemberService memberService;
     private final PostRepository postRepository;
 
+    @Transactional
     public void touchPostScrap(String providerId, long postId) {
         Optional<PostScrap> optinalScrap = postScrapRepository.findByProviderIdAndPostId(providerId, postId);
         if (optinalScrap.isPresent())

--- a/src/main/java/com/flint/flint/community/service/PostScrapUpdateService.java
+++ b/src/main/java/com/flint/flint/community/service/PostScrapUpdateService.java
@@ -1,0 +1,41 @@
+package com.flint.flint.community.service;
+
+import com.flint.flint.common.exception.FlintCustomException;
+import com.flint.flint.common.spec.ResultCode;
+import com.flint.flint.community.domain.post.Post;
+import com.flint.flint.community.domain.post.PostScrap;
+import com.flint.flint.community.repository.PostRepository;
+import com.flint.flint.community.repository.PostScrapRepository;
+import com.flint.flint.member.domain.main.Member;
+import com.flint.flint.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Service
+public class PostScrapUpdateService {
+
+    private final PostScrapRepository postScrapRepository;
+    private final MemberService memberService;
+    private final PostRepository postRepository;
+
+    public void touchPostScrap(String providerId, long postId) {
+        Optional<PostScrap> optinalScrap = postScrapRepository.findByProviderIdAndPostId(providerId, postId);
+        if (optinalScrap.isPresent())
+            postScrapRepository.delete(optinalScrap.get());
+        createScrap(providerId, postId);
+    }
+
+    private void createScrap(String providerId, long postId) {
+        Member member = memberService.getMemberByProviderId(providerId);
+        Post post = postRepository.findById(postId).orElseThrow(() -> new FlintCustomException(HttpStatus.NOT_FOUND, ResultCode.POST_NOT_FOUND));
+        PostScrap postScrap = PostScrap.builder()
+                .member(member)
+                .post(post)
+                .build();
+        postScrapRepository.save(postScrap);
+    }
+}

--- a/src/main/java/com/flint/flint/community/service/PostScrapUpdateService.java
+++ b/src/main/java/com/flint/flint/community/service/PostScrapUpdateService.java
@@ -13,8 +13,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
-
 @RequiredArgsConstructor
 @Service
 public class PostScrapUpdateService {
@@ -24,14 +22,7 @@ public class PostScrapUpdateService {
     private final PostRepository postRepository;
 
     @Transactional
-    public void touchPostScrap(String providerId, long postId) {
-        Optional<PostScrap> optinalScrap = postScrapRepository.findByProviderIdAndPostId(providerId, postId);
-        if (optinalScrap.isPresent())
-            postScrapRepository.delete(optinalScrap.get());
-        createScrap(providerId, postId);
-    }
-
-    private void createScrap(String providerId, long postId) {
+    public void createScrap(String providerId, long postId) {
         Member member = memberService.getMemberByProviderId(providerId);
         Post post = postRepository.findById(postId).orElseThrow(() -> new FlintCustomException(HttpStatus.NOT_FOUND, ResultCode.POST_NOT_FOUND));
         PostScrap postScrap = PostScrap.builder()
@@ -39,5 +30,11 @@ public class PostScrapUpdateService {
                 .post(post)
                 .build();
         postScrapRepository.save(postScrap);
+    }
+
+    @Transactional
+    public void deleteScrap(String providerId, long postId) {
+        PostScrap postScrap = postScrapRepository.findByProviderIdAndPostId(providerId, postId).orElseThrow(() -> new FlintCustomException(HttpStatus.NOT_FOUND, ResultCode.POST_SCRAP_NOT_FOUND));
+        postScrapRepository.delete(postScrap);
     }
 }

--- a/src/test/java/com/flint/flint/community/controller/PostApiControllerTest.java
+++ b/src/test/java/com/flint/flint/community/controller/PostApiControllerTest.java
@@ -6,9 +6,11 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.flint.flint.community.domain.board.Board;
 import com.flint.flint.community.domain.post.Post;
+import com.flint.flint.community.domain.post.PostScrap;
 import com.flint.flint.community.dto.request.PostRequest;
 import com.flint.flint.community.repository.BoardRepository;
 import com.flint.flint.community.repository.PostRepository;
+import com.flint.flint.community.repository.PostScrapRepository;
 import com.flint.flint.community.spec.BoardType;
 import com.flint.flint.custom_member.WithMockCustomMember;
 import com.flint.flint.member.domain.main.Member;
@@ -44,6 +46,8 @@ class PostApiControllerTest {
     private ObjectMapper objectMapper;
     @Autowired
     PostRepository postRepository;
+    @Autowired
+    PostScrapRepository postScrapRepository;
 
     private static final String BASE_URL = "/api/v1/posts";
 
@@ -145,8 +149,60 @@ class PostApiControllerTest {
         Long postId = post.getId();
 
         //when,then
-        mockMvc.perform(post(BASE_URL+"/heart/" + postId))
+        mockMvc.perform(post(BASE_URL + "/like/" + postId))
                 .andExpect(status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.postLikeCount").value(1)); // 응답 JSON에서 likeCount 값 확인
+    }
+
+    @Test
+    @DisplayName("게시글 스크랩 생성 테스트")
+    @Transactional
+    @WithMockCustomMember(role = "ROLE_AUTHUSER")
+    void test4() throws Exception {
+        //given
+        Member member = Member.builder()
+                .name("테스터")
+                .email("test@test.com")
+                .providerName("kakao")
+                .providerId("kakao test")
+                .build();
+
+        memberRepository.save(member);
+
+        Post post = Post.builder().title("테스트 제목입니다.").contents("테스트 내용입니다.").build();
+
+        postRepository.save(post);
+
+
+        Long postId = post.getId();
+
+        //when,then
+        mockMvc.perform(post(BASE_URL + "/scrap/" + postId))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("게시글 스크랩 취소 테스트")
+    @Transactional
+    @WithMockCustomMember(role = "ROLE_AUTHUSER")
+    void test5() throws Exception {
+        //given
+        Member member = Member.builder()
+                .name("테스터")
+                .email("test@test.com")
+                .providerName("kakao")
+                .providerId("kakao test")
+                .build();
+
+        Post post = Post.builder().title("테스트 제목입니다.").contents("테스트 내용입니다.").build();
+
+        PostScrap postScrap = PostScrap.builder().post(post).member(member).build();
+        memberRepository.save(member);
+        postRepository.save(post);
+        postScrapRepository.save(postScrap);
+
+        //when,then
+        mockMvc.perform(post(BASE_URL+"/scrap/" + post.getId()))
+                .andExpect(status().isOk());
     }
 }

--- a/src/test/java/com/flint/flint/community/controller/PostApiControllerTest.java
+++ b/src/test/java/com/flint/flint/community/controller/PostApiControllerTest.java
@@ -28,6 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -202,7 +203,7 @@ class PostApiControllerTest {
         postScrapRepository.save(postScrap);
 
         //when,then
-        mockMvc.perform(post(BASE_URL+"/scrap/" + post.getId()))
+        mockMvc.perform(delete(BASE_URL+"/scrap/" + post.getId()))
                 .andExpect(status().isOk());
     }
 }


### PR DESCRIPTION
## 관련 이슈
close #100 
## 변경사항
- 게시글 스크랩 생성/취소 API 구현
## 개발하면서 발생한 문제점과 해결방안 또는 새롭게 알게된 점
x
## 당부하고 싶은 말 또는 논의해봐야할 점
기존 게시글, 게시글 댓글 좋아요 생성/취소 API를 구현할 때 하나의 API로 구현하였습니다. 이번 스크랩 API도 좋아요 API와 똑같은 로직으로 구현 도중 생성(POST), 삭제(DELETE)가 하나의 HTTP 메소드인 POST에  두 개 다있어도 되는지 의견을 여쭤보고 싶어요. 
아 그리고 이번에 우테코 과제 준비하면서 객체지향(책임 분리)에 대해서 생각해볼 기회가 있어서 메소드 분리 좀 신경 썻습니당 ㅋㅋㅋㅋ
## 스크린샷
![image](https://github.com/Flint-org/Flint-API-Server/assets/92251131/31f28522-154f-4a7d-b690-5afc9f82dced)

## 기타 및 추후 계획

