### PR TITLE
Refactor: 로그인 /회원가입 예외 로직 추가

### DIFF
--- a/src/main/java/com/flint/flint/common/spec/ResultCode.java
+++ b/src/main/java/com/flint/flint/common/spec/ResultCode.java
@@ -27,6 +27,8 @@ public enum ResultCode {
     USER_NOT_FOUND("F300", "존재하지 않는 유저입니다."),
     USER_MANY_REQUEST("F301", "사용자의 API요청이 제한됩니다."),
     USER_UNIVERSITY_CERTIFICATION_NOT_FOUND("F302", "유저의 대학 정보가 없습니다"),
+    USER_ALREADY_JOIN("F303", "이미 회원가입된 유저입니다."),
+    USER_NOT_JOINED("F304", "회원가입이 되어있지 않은 유저입니다."),
 
     // F4xx: 커뮤니티, 게시글 예외
     MAJOR_BOARD_NOT_FOUND("F400", "존재하지 않는 전공 게시판입니다."),

--- a/src/main/java/com/flint/flint/common/spec/ResultCode.java
+++ b/src/main/java/com/flint/flint/common/spec/ResultCode.java
@@ -22,6 +22,7 @@ public enum ResultCode {
     MAIL_AUTHNUMBER_NOT("F200", "인증번호가 틀립니다."),
     AUTH_USER_NOT("F201", "현재 권한으로 접근 불가능합니다."),
     JWT_DATE_NOT("F202", "JWT토큰이 만료되었습니다."),
+    REFRESHTOKEN_OUTDATED("F203", "새로 발급된 토큰보다 이전의 리프레시 토큰입니다."),
 
     // F3xx: 유저 예외
     USER_NOT_FOUND("F300", "존재하지 않는 유저입니다."),

--- a/src/main/java/com/flint/flint/security/auth/AuthenticationService.java
+++ b/src/main/java/com/flint/flint/security/auth/AuthenticationService.java
@@ -96,12 +96,12 @@ public class AuthenticationService {
         String refreshToken = jwtService.generateRefreshToken(claimsDTO);
         redisUtil.save(providerId, refreshToken, refreshTokenExpiration);
 
-            return AuthenticationResponse.builder()
-                    .accessToken(accessToken)
-                    .refreshToken(refreshToken)
-                    .accessTokenExpiration(jwtService.parseExpiration(accessToken))
-                    .refreshTokenExpiration(jwtService.parseExpiration(refreshToken))
-                    .build();
-        }
+        return AuthenticationResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .accessTokenExpiration(jwtService.parseExpiration(accessToken))
+                .refreshTokenExpiration(jwtService.parseExpiration(refreshToken))
+                .build();
+    }
 
 }


### PR DESCRIPTION
## 관련 이슈
close #113 
## 변경사항
- 회원가입 코드 분리 
- 로그인/회원가입 예외 로직(회원가입 되어 있는지) 추가
- 리프레쉬토큰으로 새로운 토큰 발급 받는 API에서 리프레쉬토큰이 최신 리프레쉬 토큰인지 레디스에서 비교하여 검증하는 로직 추가
## 개발하면서 발생한 문제점과 해결방안 또는 새롭게 알게된 점
레디스에 리프레쉬 토큰을 저장만 해놓고 정작, 레디스를 이용하여 리프레쉬토큰을 검증하는 코드를 뺴놓았습니다. 이번에 리팩토링하며 추가하였습니다.
## 당부하고 싶은 말 또는 논의해봐야할 점
## 스크린샷
## 기타 및 추후 계획
승건님께서 말씀하신 페이징 관련 리팩토링 할 예정입니다.

