### PR TITLE
fix: 이메일 보내기 API 

### DIFF
--- a/src/main/java/com/flint/flint/mail/service/RateLimitService.java
+++ b/src/main/java/com/flint/flint/mail/service/RateLimitService.java
@@ -19,12 +19,13 @@ public class RateLimitService {
     private final RedisUtil redisUtil;
 
     public Boolean checkAPICall(Long key) {
-        String apiCall = String.valueOf(redisUtil.findAPICallByKey(key));
+        Object apiCall = redisUtil.findAPICallByKey(key);
+
         if (apiCall == null) { //한 번도 호출 안 한 경우
-            redisUtil.saveAPICall(key, String.valueOf((int)1), Expiration);
+            redisUtil.saveAPICall(key, String.valueOf(1), Expiration);
             return true;
-        } else if (Integer.parseInt(apiCall) < MAX_API_CALL) { //10 번 미만 호출 한 경우
-            redisUtil.updateAPICall(key, String.valueOf(Integer.parseInt(apiCall) + 1));
+        } else if (Integer.parseInt((String) apiCall) < MAX_API_CALL) { //10 번 미만 호출 한 경우
+            redisUtil.updateAPICall(key, String.valueOf(Integer.parseInt((String) apiCall) + 1));
             return true;
         }
         return false; //10 번인 경우

--- a/src/main/java/com/flint/flint/member/domain/main/Member.java
+++ b/src/main/java/com/flint/flint/member/domain/main/Member.java
@@ -53,6 +53,7 @@ public class Member extends BaseTimeEntity {
     private String providerName;
 
     @NotNull
+    @Column(unique = true)
     private String providerId;
 
     @Builder

--- a/src/main/java/com/flint/flint/security/auth/AuthenticationController.java
+++ b/src/main/java/com/flint/flint/security/auth/AuthenticationController.java
@@ -27,7 +27,6 @@ public class AuthenticationController {
     public ResponseForm<AuthenticationResponse> register(@Valid @RequestBody RegisterRequest registerRequest, HttpServletRequest oauth2TokenWithBearer) {
         AuthenticationResponse authenticationResponse = authenticationService.register(registerRequest, oauth2TokenWithBearer);
         return new ResponseForm<>(authenticationResponse);
-
     }
 
     @PostMapping("/login/{providerName}")

--- a/src/main/java/com/flint/flint/security/oauth/KakaoOAuth2UserAttribute.java
+++ b/src/main/java/com/flint/flint/security/oauth/KakaoOAuth2UserAttribute.java
@@ -13,6 +13,7 @@ import java.util.Map;
 
 /**
  * 카카오에서 받아오는 사용자 정보 담는 DTO
+ *
  * @Author 정순원
  * @Since 2023-08-19
  */
@@ -32,18 +33,20 @@ public class KakaoOAuth2UserAttribute extends OAuth2UserAttribute {
 
         return Member.builder()
                 .providerName(KAKAO_PROVIDER_ID)
-                .providerId(KAKAO_PROVIDER_ID+" "+getProviderId())//띄어쓰기 포함
+                .providerId(getProviderId())//띄어쓰기 포함
                 .email(getEmail())
                 .name(getName())
                 .gender(Gender.valueOf(getGender().toUpperCase())) //대소문자 구별하니 바꿔줘야 함
-                .authority(Authority.AUTHUSER)
+                .authority(Authority.UNAUTHUSER)
                 .birthday(getBirthday())
                 .build();
     }
 
     //TODO
     @Override
-    public String getProviderId() { return "kakao " + this.id;}
+    public String getProviderId() {
+        return KAKAO_PROVIDER_ID + "_" + this.id;
+    }
 
     @Override
     public String getEmail() {
@@ -66,17 +69,18 @@ public class KakaoOAuth2UserAttribute extends OAuth2UserAttribute {
     }
 
     @Override
-    public void setUserAttributesByOauthToken(String authorizionRequestHeader) {
+    public void setUserAttributesByOauthToken(String kakaoAccessToken) {
 
 
         JSONObject response = WebClient.create()
                 .get()
                 .uri("https://kapi.kakao.com/v2/user/me")
-                .headers(httpHeaders -> httpHeaders.setBearerAuth(authorizionRequestHeader))
+                .headers(httpHeaders -> httpHeaders.setBearerAuth(kakaoAccessToken))
                 .retrieve()
                 .bodyToMono(JSONObject.class)
                 .block();
+
         this.id = response.get("id").toString();
-        this.kakaoAccount = (Map<String, Object>)response.get("kakao_account");
+        this.kakaoAccount = (Map<String, Object>) response.get("kakao_account");
     }
 }

--- a/src/main/java/com/flint/flint/security/oauth/NaverOAuth2UserAttribute.java
+++ b/src/main/java/com/flint/flint/security/oauth/NaverOAuth2UserAttribute.java
@@ -13,6 +13,7 @@ import java.util.Map;
 
 /**
  * 네이버에서 받아오는 사용자 정보 담는 DTO
+ *
  * @Author 정순원
  * @Since 2023-08-19
  */
@@ -30,11 +31,11 @@ public class NaverOAuth2UserAttribute extends OAuth2UserAttribute {
     public Member toEntity() {
         return Member.builder()
                 .providerName(NAVER_PROVIDER_ID)
-                .providerId(NAVER_PROVIDER_ID + " " + getProviderId())
+                .providerId(getProviderId())
                 .email(getEmail())
                 .name(getName())
                 .gender(Gender.valueOf(getGender().toUpperCase())) //대소문자 구별하니 바꿔줘야 함
-                .authority(Authority.AUTHUSER)
+                .authority(Authority.UNAUTHUSER)
                 .birthday(getBirthday())
                 .build();
     }
@@ -75,6 +76,6 @@ public class NaverOAuth2UserAttribute extends OAuth2UserAttribute {
                 .retrieve()
                 .bodyToMono(JSONObject.class)
                 .block();
-        this.response = (Map<String, Object>)naverResponse.get("response");
+        this.response = (Map<String, Object>) naverResponse.get("response");
     }
 }


### PR DESCRIPTION
## 관련 이슈
close #128
## 변경사항
- String.valueOf(redisUtil.findAPICallByKey(key)); 
key를 통해 String을 가져오는 문장입니다. 한 번도 호출하지 않은 경우 null 일 수도 있기 때문에 String.valueOf를 없앴습니다.

- providerId를 저장할 때 kakao_12131가 아닌 kakao_kakao_12131 저장되어 있어 이 부분도 수정했습니다.

## 개발하면서 발생한 문제점과 해결방안 또는 새롭게 알게된 점
## 당부하고 싶은 말 또는 논의해봐야할 점
## 스크린샷
10번 이상 호출하였을 때
![image](https://github.com/Flint-org/Flint-API-Server/assets/92251131/5a0ed7e9-a0dd-482f-b0b7-0ab1c71b53eb)

## 기타 및 추후 계획

